### PR TITLE
fix: update page title on repo switch

### DIFF
--- a/src/Main.purs
+++ b/src/Main.purs
@@ -29,7 +29,7 @@ main = HA.runHalogenAff do
 
 type Slots =
   ( repoManager :: H.Slot RM.Query RM.Output Unit
-  , viewer :: forall q. H.Slot q Void Unit
+  , viewer :: forall q. H.Slot q Void String
   )
 
 _repoManager :: Proxy "repoManager"
@@ -73,14 +73,14 @@ appRender state =
     [ HH.slot _repoManager unit RM.repoManager unit
         HandleRepo
     , HH.div [ cls "main-area" ]
-        [ case state.dataUrls of
-            Nothing ->
+        [ case state.activeRepo, state.dataUrls of
+            Just repo, Just urls ->
+              HH.slot_ _viewer repo.id Viewer.viewer urls
+            _, _ ->
               HH.div [ cls "empty-main" ]
                 [ HH.text
                     "Add a repository to get started"
                 ]
-            Just urls ->
-              HH.slot_ _viewer unit Viewer.viewer urls
         ]
     ]
 


### PR DESCRIPTION
Viewer slot was keyed by unit, so switching repos kept the old component
mounted with stale document.title. Now keyed by repo ID — Halogen
remounts Viewer on switch, running Initialize which sets the title.