### PR TITLE
fix: publish lib variant for build-action

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,11 @@ jobs:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - run: |
           nix develop --quiet -c just install
-          nix develop --quiet -c just bundle
+          nix develop --quiet -c just bundle-lib
+          mkdir -p dist/lib
+          cp dist/index.html dist/lib/index.html
+          cp dist/index.js dist/lib/index.js
+          nix develop --quiet -c just bundle-app
           cp -r schema dist/schema
       - uses: actions/upload-pages-artifact@v4
         with:

--- a/build-action/action.yml
+++ b/build-action/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: |
         OUT="${{ inputs.output-dir }}"
-        BASE="https://lambdasistemi.github.io/graph-browser"
+        BASE="https://lambdasistemi.github.io/graph-browser/lib"
         mkdir -p "$OUT"
         curl -sfL "$BASE/index.html" -o "$OUT/index.html"
         curl -sfL "$BASE/index.js" -o "$OUT/index.js"


### PR DESCRIPTION
Pages now serves both app (root) and lib (/lib/) variants. build-action fetches the lib variant so data repos get the standalone viewer.