### PR TITLE
fix: show node/edge details below tutorial step on hover

### DIFF
--- a/src/Viewer.purs
+++ b/src/Viewer.purs
@@ -299,7 +299,16 @@ renderSidebar state =
         ]
     , HH.div [ cls "sidebar-content" ]
         [ if state.tutorialActive then
-            renderTutorialContent state
+            HH.div_
+              ( [ renderTutorialContent state ]
+                  <> case state.hoveredEdge of
+                    Just edge ->
+                      [ renderEdgeDetail state edge ]
+                    Nothing -> case state.hoveredNode of
+                      Just node ->
+                        [ renderNodeDetail state node ]
+                      Nothing -> []
+              )
           else case state.hoveredEdge of
             Just edge -> renderEdgeDetail state edge
             Nothing -> case state.selected of


### PR DESCRIPTION
During guided tours, hovering a node or edge now appends its details below the tutorial step instead of hiding or replacing the tutorial content.