### PR TITLE
feat: publish ontology namespace pages from Turtle

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,9 @@ Without a manifest, the app looks for `data/` on the repo's main branch via raw 
 ```bash
 nix develop -c just ci          # lint + build + bundle
 nix develop -c just export-rdf  # regenerate data/rdf from the graph sources declared in data/config.json
+nix develop -c just publish-vocab # generate /vocab/... namespace pages from ontology Turtle
 nix develop -c just validate-rdf # validate RDF artifacts with SHACL
+nix develop -c just build-docs  # build docs, copy RDF artifacts, and publish /vocab/... pages into dist
 nix develop -c just serve       # serve example on port 10002
 nix develop -c just dev         # watch mode
 nix develop -c just bundle-app  # bundle app (with repo panel)
@@ -258,6 +260,27 @@ The command writes:
 - `data/rdf/application-shapes.ttl`
 
 `core-ontology.ttl` is the shared graph-browser ontology. `application-ontology.ttl` is the repo-specific extension generated from local kinds, groups, and edge labels. `core-ontology.mmd` and `application-ontology.mmd` are generated Mermaid views of the same structures for lightweight visualization and Pages publishing.
+
+`just publish-vocab` reads the ontology Turtle artifacts and generates human-browsable namespace pages under:
+
+- `dist/vocab/terms`
+- `dist/vocab/kinds`
+- `dist/vocab/groups`
+- `dist/vocab/edges`
+
+Those pages are generated automatically from Turtle during the docs/site build. They are not maintained as a separate hardcoded term catalog.
+
+This matters because ontology IRIs like `https://lambdasistemi.github.io/graph-browser/vocab/terms#Node` rely on the namespace document `https://lambdasistemi.github.io/graph-browser/vocab/terms` being published. The `#Node` fragment is client-side only.
+
+Downstream repos can use the same Turtle-driven generator through the reusable action:
+
+```yaml
+- uses: lambdasistemi/graph-browser/vocab-publish-action@main
+  with:
+    sources: data/rdf/core-ontology.ttl,data/rdf/application-ontology.ttl
+    output-dir: site
+    site-base-path: /your-repo-name
+```
 
 `just validate-rdf` runs two SHACL checks:
 

--- a/docs/ontology/index.md
+++ b/docs/ontology/index.md
@@ -8,6 +8,8 @@ The shared ontology lives at [`/rdf/core-ontology.ttl`](https://lambdasistemi.gi
 
 A generated Mermaid view of the same structure is published at [`/rdf/core-ontology.mmd`](https://lambdasistemi.github.io/graph-browser/rdf/core-ontology.mmd).
 
+The corresponding namespace page is published at [`/vocab/terms`](https://lambdasistemi.github.io/graph-browser/vocab/terms). Hash IRIs like `gb:Node` resolve through that namespace document.
+
 - `gb:Dataset`
 - `gb:Node`
 - `gb:Group`
@@ -26,6 +28,12 @@ It also defines the shared relationships and datatype properties used by exporte
 The application ontology lives at [`/rdf/application-ontology.ttl`](https://lambdasistemi.github.io/graph-browser/rdf/application-ontology.ttl). It is generated from repository data and contains:
 
 A generated Mermaid view of the repository-specific vocabulary is published at [`/rdf/application-ontology.mmd`](https://lambdasistemi.github.io/graph-browser/rdf/application-ontology.mmd).
+
+The corresponding namespace pages are published at:
+
+- [`/vocab/kinds`](https://lambdasistemi.github.io/graph-browser/vocab/kinds)
+- [`/vocab/groups`](https://lambdasistemi.github.io/graph-browser/vocab/groups)
+- [`/vocab/edges`](https://lambdasistemi.github.io/graph-browser/vocab/edges)
 
 - local node kinds
 - local groups

--- a/justfile
+++ b/justfile
@@ -47,10 +47,16 @@ render-rdf-diagrams: export-rdf
     mmdc -p mermaid-puppeteer-config.json -i data/rdf/core-ontology.mmd -o data/rdf/core-ontology.svg -t dark -b transparent
     mmdc -p mermaid-puppeteer-config.json -i data/rdf/application-ontology.mmd -o data/rdf/application-ontology.svg -t dark -b transparent
 
+publish-vocab:
+    NODE_OPTIONS="--require ./src/oxigraph-shim.cjs" spago run --main Vocab.Publish.Main -- --output-dir dist --site-base-path /graph-browser --sources data/rdf/core-ontology.ttl,data/rdf/application-ontology.ttl
+
 build-docs: render-rdf-diagrams
     mkdocs build --strict --site-dir dist/docs
     rm -rf dist/rdf
     cp -r data/rdf dist/rdf
+    just publish-vocab
+
+build-site: build-docs
 
 validate-rdf:
     shacl validate --shapes data/rdf/shapes.ttl --data data/rdf/graph.ttl

--- a/specs/009-publish-ontology-namespaces/data-model.md
+++ b/specs/009-publish-ontology-namespaces/data-model.md
@@ -1,0 +1,57 @@
+# Data Model: Publish Dereferenceable Ontology Namespaces
+
+## Ontology Triple Source
+
+- **Purpose**: The Turtle-derived triples used as the source of truth for namespace publication.
+- **Required attributes**:
+  - `sourcePath`: path to a Turtle ontology input or derived Turtle artifact
+  - `format`: RDF syntax, expected to be Turtle for this issue
+  - `namespace`: namespace detected or assigned for publication
+- **Notes**:
+  - A namespace page may be assembled from one or more Turtle files contributing triples to the same namespace.
+
+## Ontology Term Entry
+
+- **Purpose**: Represents one generated identifier inside a namespace document.
+- **Required attributes**:
+  - `iri`: full ontology term IRI
+  - `namespace`: namespace document URL without fragment
+  - `fragment`: fragment identifier appended after `#`
+  - `compactName`: compact prefixed form such as `gb:Node`
+  - `label`: human-facing label, when present
+  - `description`: human-facing description, when present
+  - `termType`: broad type such as class, object property, datatype property, annotation property, or repository-derived vocabulary item
+- **Notes**:
+  - The entry is extracted from Turtle triples, not from a manually curated inventory.
+  - Missing `rdfs:label` or `dcterms:description` must not prevent publication.
+
+## Namespace Document
+
+- **Purpose**: A published page representing a vocabulary namespace such as `terms`, `kinds`, `groups`, or `edges`.
+- **Required attributes**:
+  - `namespaceUrl`: canonical namespace URL without fragment
+  - `title`: human-facing page title
+  - `description`: short explanation of the vocabulary scope
+  - `sourceArtifacts`: links to the underlying ontology Turtle or related generated artifacts
+  - `terms`: ordered collection of generated ontology term entries
+- **Notes**:
+  - The document is emitted automatically into the Pages artifact.
+
+## Ontology Identity
+
+- **Purpose**: The UI-facing identity block shown for a selected ontology-backed node.
+- **Required attributes**:
+  - `iri`: full ontology term IRI
+  - `compact`: compact prefixed representation when known
+  - `namespace`: namespace URL
+  - `namespaceLabel`: short human-facing namespace name or fallback URL
+
+## Namespace Publication Step
+
+- **Purpose**: The automated build/deploy step that reads Turtle inputs and emits namespace documents to the final site artifact.
+- **Required attributes**:
+  - `inputs`: ontology Turtle files or exported ontology artifacts
+  - `outputDir`: site output directory receiving `/vocab/...`
+  - `publishedNamespaces`: collection of namespace documents generated during the build
+- **Notes**:
+  - This is the reuse boundary that downstream repos should be able to adopt.

--- a/specs/009-publish-ontology-namespaces/plan.md
+++ b/specs/009-publish-ontology-namespaces/plan.md
@@ -1,0 +1,99 @@
+# Implementation Plan: Publish Dereferenceable Ontology Namespaces
+
+**Branch**: `009-publish-ontology-namespaces` | **Date**: 2026-04-09 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/009-publish-ontology-namespaces/spec.md`
+
+## Summary
+
+Publish real namespace documents at the existing `https://lambdasistemi.github.io/graph-browser/vocab/...` URLs by generating them automatically from ontology Turtle during the build/deploy path. The implementation should preserve the current ontology IRIs, keep the viewer’s ontology identity UI, and move namespace publication into a reusable automation path so downstream repos can publish their own ontology namespaces without writing hardcoded term catalogs.
+
+## Technical Context
+
+**Language/Version**: PureScript (Spago), JavaScript FFI only where already present, shell/GitHub Actions for build wiring  
+**Primary Dependencies**: Halogen, Oxigraph WASM FFI, MkDocs, GitHub Pages workflow  
+**Storage**: Static files in the deployed Pages artifact  
+**Testing**: `just test`, `nix build`, Pages-style local build, manual browser verification against local build and deployed preview  
+**Target Platform**: Browser and GitHub Pages static hosting  
+**Project Type**: Web application plus generated static documentation assets  
+**Performance Goals**: Namespace publication should fit inside the existing docs/build workflow without adding a large custom maintenance burden  
+**Constraints**: Preserve existing ontology IRIs; keep Turtle as source of truth; avoid per-project hardcoded term inventories; make the publication path reusable  
+**Scale/Scope**: Graph-browser core vocabulary plus repository-derived kinds, groups, and edge predicates, with a reusable path for downstream repos
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Data-Driven, Zero Hardcoding | PASS | Namespace pages must be derived from Turtle triples, not maintained term-by-term in source |
+| II. PureScript for Logic, JS FFI for Rendering | PASS | Parsing/generation logic belongs in PureScript; no new JS business logic is needed |
+| III. Nix-First Builds | PASS | Publication belongs in the existing Nix-backed build/deploy flow |
+| IV. Library/App Split | PASS | Viewer identity rendering remains shared; namespace publication is a deploy-time artifact concern |
+| V. Schema-Validated Data | PASS | No new JSON schema is required; ontology publication is derived from TTL inputs already produced by the repo |
+| VI. Accessibility of Information | PASS | This feature directly improves inspectability and trust of ontology-backed content |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-publish-ontology-namespaces/
+├── plan.md
+├── research.md
+├── data-model.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── Viewer.purs                 # REUSE/MODIFY if needed: ontology identity in the right panel
+├── Rdf/
+│   ├── Export.purs            # REUSE: ontology IRIs and exported TTL remain authoritative inputs
+│   └── Export/
+│       └── Main.purs          # POSSIBLE REUSE if namespace generation is wired near export
+├── Ontology/
+│   └── ...                    # POSSIBLE NEW/REUSED parsing/publishing logic derived from TTL
+└── FFI/
+    └── Node.purs/.js          # REUSE: writing generated namespace pages into dist
+
+justfile                        # MODIFY: add namespace generation into the build/docs path
+.github/workflows/pages.yml     # MODIFY: ensure deployed Pages artifact contains generated /vocab/... pages
+README.md                       # MODIFY: document namespace publication and fragment behavior
+docs/                           # OPTIONAL MODIFY: link human docs to the published namespace pages
+```
+
+**Structure Decision**: Keep ontology publication derived from Turtle and wire it into the existing build/deploy path. Avoid introducing a repo-specific hardcoded vocabulary module that would have to be rewritten in downstream repos.
+
+## Design Decisions
+
+### D1: Preserve existing ontology IRIs
+
+**Decision**: Keep the current `https://lambdasistemi.github.io/graph-browser/vocab/...#...` IRIs unchanged.
+
+**Rationale**: Existing RDF exports and downstream references already use these identifiers. The problem is publication, not naming.
+
+### D2: Generate namespace pages from Turtle
+
+**Decision**: Build namespace pages by reading ontology Turtle inputs or triples derived from them.
+
+**Rationale**: Turtle is the ontology source of truth. Downstream repos should not need to maintain hand-written term catalogs in code.
+
+### D3: Put namespace publication in the build/deploy path
+
+**Decision**: The Pages artifact assembly must generate `/vocab/terms`, `/vocab/kinds`, `/vocab/groups`, and `/vocab/edges`.
+
+**Rationale**: The feature only matters if the deployed site contains those paths. Local-only generation is insufficient.
+
+### D4: Keep viewer ontology provenance in scope
+
+**Decision**: The right-hand panel continues to show compact prefixed terms, full term links, and namespace links only when ontology provenance exists.
+
+**Rationale**: Publishing namespace pages alone is not enough unless users can navigate to them from the graph UI.
+
+### D5: Human-readable first, reusable later
+
+**Decision**: First iteration generates stable human-readable namespace pages from TTL, with links back to the underlying ontology artifacts.
+
+**Rationale**: This satisfies dereferenceability now and creates the right reusable abstraction for downstream repos without blocking on content negotiation.

--- a/specs/009-publish-ontology-namespaces/research.md
+++ b/specs/009-publish-ontology-namespaces/research.md
@@ -1,0 +1,34 @@
+# Research: Publish Dereferenceable Ontology Namespaces
+
+## Decision: Namespace pages must be generated from Turtle, not from hardcoded term metadata
+
+- **Why**: The ontology is authored in Turtle. Encoding the same vocabulary again in repo-specific code would recreate the multiple-sources-of-truth problem that issue 56 just removed on the graph side.
+- **Alternatives considered**:
+  - Hand-maintained term lists in PureScript: rejected because every downstream project would need custom code and the page content would drift from the ontology.
+  - Pure prose markdown pages: rejected because they do not scale to generated vocabularies such as kinds, groups, and edges.
+
+## Decision: The automation boundary is the build/deploy workflow
+
+- **Why**: The desired behavior is a deployed property of the site. If the Pages artifact does not contain `/vocab/...`, the links shown in the UI will still fail.
+- **Alternatives considered**:
+  - Generate pages only in local development: rejected because it does not solve deployment.
+  - Keep generation inside graph-browser-only source code without workflow integration: rejected because downstream reuse becomes awkward and manual.
+
+## Decision: Graph-browser should prove the pattern, but the abstraction must be reusable
+
+- **Why**: Graph-browser is the first consumer, but the user requirement is broader: any project using graph-browser and authoring an ontology in Turtle should be able to publish dereferenceable namespace pages.
+- **Alternatives considered**:
+  - Solve only for `gb:` namespaces with graph-browser-specific hardcoded catalogs: rejected because it does not generalize.
+  - Defer downstream reuse entirely: rejected because the issue is about establishing the right publication model.
+
+## Decision: Viewer ontology provenance stays in scope
+
+- **Why**: A correct deployed namespace page is still invisible to users unless the viewer shows compact prefixes and links them.
+- **Alternatives considered**:
+  - Publish docs only and defer UI changes: rejected because the user-facing symptom remains unresolved.
+
+## Decision: First iteration remains static HTML, not content negotiation
+
+- **Why**: GitHub Pages is static and the immediate requirement is dereferenceable, human-browsable namespace documents.
+- **Alternatives considered**:
+  - Full RDF/HTML content negotiation: rejected for now as unnecessary complexity.

--- a/specs/009-publish-ontology-namespaces/spec.md
+++ b/specs/009-publish-ontology-namespaces/spec.md
@@ -1,0 +1,97 @@
+# Feature Specification: Publish Dereferenceable Ontology Namespaces
+
+**Feature Branch**: `009-publish-ontology-namespaces`  
+**Created**: 2026-04-09  
+**Status**: Draft  
+**Input**: User description: "Publish dereferenceable ontology namespace documents and ontology term links"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Follow ontology terms from the viewer (Priority: P1)
+
+As a graph-browser user exploring ontology-backed content, I want ontology terms to show their prefixed identity and open to a real published namespace document so I can verify what a class or predicate means without encountering broken links.
+
+**Why this priority**: The ontology view is not credible unless the links shown in the UI resolve to real published ontology material.
+
+**Independent Test**: Open an ontology-backed node in the viewer, inspect its ontology identity, and click the term or namespace link. The destination must resolve to a published namespace page instead of a 404.
+
+**Acceptance Scenarios**:
+
+1. **Given** a node with an ontology IRI in the viewer, **When** the user opens its detail panel, **Then** the panel shows a compact prefixed identity and links to a published ontology term.
+2. **Given** a term IRI such as `.../vocab/terms#Node`, **When** the user follows it in a browser, **Then** the namespace document for `.../vocab/terms` loads successfully and the requested term can be identified within that document.
+
+---
+
+### User Story 2 - Publish namespace pages automatically from Turtle (Priority: P1)
+
+As a maintainer of graph-browser or a downstream graph-browser data repo, I want namespace pages to be generated from ontology Turtle files during the build so I do not have to hand-maintain project-specific code for each vocabulary.
+
+**Why this priority**: Hardcoded namespace page logic does not scale across repositories. The ontology itself is already authored in Turtle and should remain the source of truth.
+
+**Independent Test**: Provide ontology Turtle inputs to the build, run the publication step, and verify that namespace pages are generated automatically for the configured vocabularies without any hand-written term inventory.
+
+**Acceptance Scenarios**:
+
+1. **Given** ontology Turtle files containing classes and properties in a namespace, **When** the build runs, **Then** it generates a namespace page by extracting term information from those triples.
+2. **Given** a downstream project with its own ontology Turtle files, **When** it uses the same generation path, **Then** it can publish dereferenceable namespace pages without adding repo-specific PureScript code that lists every term manually.
+
+---
+
+### User Story 3 - Reuse the publication path in the build/deploy workflow (Priority: P2)
+
+As a maintainer shipping a GitHub Pages deployment, I want namespace publication to live in the reusable build/deploy path so ontology pages are produced consistently by automation rather than by local manual steps.
+
+**Why this priority**: The desired behavior is operational, not just local. If the GitHub action does not generate the pages, the links will still break in deployed environments.
+
+**Independent Test**: Run the Pages-style build locally or in CI and confirm that the deployed artifact contains `/vocab/terms`, `/vocab/kinds`, `/vocab/groups`, and `/vocab/edges` produced by the automated publication step.
+
+**Acceptance Scenarios**:
+
+1. **Given** the build or deploy workflow for graph-browser, **When** it assembles the final Pages artifact, **Then** the artifact includes generated namespace pages at the expected `/vocab/...` paths.
+2. **Given** the same generation logic is exposed through the reusable build path, **When** downstream repos adopt it, **Then** they can publish ontology namespace pages through automation rather than handwritten custom code.
+
+### Edge Cases
+
+- What happens when a node has no ontology IRI at all? The viewer must avoid showing empty or misleading ontology identity controls.
+- What happens when a term belongs to an unknown namespace? The viewer must still show the full IRI and link to the namespace document without inventing a prefix.
+- What happens when an ontology term contains characters that require fragment encoding? The generated namespace page must still allow the user to identify the requested term.
+- What happens when a namespace document is generated from Turtle but a term lacks `rdfs:label` or `dcterms:description`? The generator must still publish a usable entry, falling back to the fragment or IRI local name.
+- What happens when multiple Turtle files contribute to the same namespace? The generator must merge those triples into one namespace page without duplicating the same term entry.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The published graph-browser site MUST expose dereferenceable namespace documents for the ontology namespaces used by the exported `gb:` vocabularies.
+- **FR-002**: The published namespace documents MUST cover the vocabulary categories currently used by graph-browser term IRIs: terms, kinds, groups, and edges.
+- **FR-003**: Namespace pages MUST be generated from ontology Turtle inputs or triples derived from those Turtle inputs, rather than from a manually maintained hardcoded term inventory.
+- **FR-004**: The generation path MUST preserve existing ontology term IRIs already emitted by RDF export, rather than replacing them with a new namespace scheme.
+- **FR-005**: Users MUST be able to follow ontology term and namespace links from the viewer to published namespace documents without encountering broken links.
+- **FR-006**: The viewer MUST present ontology identity for ontology-backed nodes in a way that preserves namespace provenance for known vocabularies.
+- **FR-007**: The build or deploy workflow MUST generate and publish namespace pages automatically as part of the Pages artifact assembly.
+- **FR-008**: The documentation for graph-browser MUST explain the namespace publication policy, including the fact that hash-fragment ontology identifiers depend on publishing the namespace document without the fragment.
+- **FR-009**: The publication path MUST be reusable by downstream graph-browser data repositories that author ontology Turtle files.
+
+### Key Entities *(include if feature involves data)*
+
+- **Ontology Namespace Document**: A published document representing a vocabulary namespace such as `gb:` terms, kinds, groups, or edges.
+- **Ontology Term Entry**: A generated entry for one ontology identifier, derived from Turtle triples and shown inside a namespace document.
+- **Ontology Identity**: The UI-facing identity block shown for a selected ontology-backed node, including compact prefix, full IRI, and namespace provenance.
+- **Namespace Publication Step**: The automated build/deploy step that reads Turtle inputs and emits the namespace documents into the final Pages artifact.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can click ontology term links for graph-browser vocabulary terms from the viewer and reach a non-404 destination in one navigation step.
+- **SC-002**: All published namespace URLs used by graph-browser ontology IRIs resolve successfully in the deployed site.
+- **SC-003**: Namespace pages are generated automatically from Turtle during the build, without requiring a hand-maintained per-project term catalog in source code.
+- **SC-004**: A downstream graph-browser repository can adopt the same publication path for its own ontology Turtle files without implementing custom code that enumerates every ontology term manually.
+- **SC-005**: A user inspecting an ontology-backed node can distinguish graph-browser vocabulary terms from standard RDF/OWL terms without reading source code.
+
+## Assumptions
+
+- The existing graph-browser ontology IRIs under `https://lambdasistemi.github.io/graph-browser/vocab/...` remain the canonical public identifiers.
+- GitHub Pages remains the publication target for the graph-browser site.
+- The ontology source of truth is Turtle, not JSON.
+- Machine-readable content negotiation is not required for the first iteration as long as namespace URLs resolve to stable published documentation derived from Turtle.

--- a/specs/009-publish-ontology-namespaces/tasks.md
+++ b/specs/009-publish-ontology-namespaces/tasks.md
@@ -1,0 +1,45 @@
+# Tasks: Publish Dereferenceable Ontology Namespaces
+
+**Input**: Design documents from `/specs/009-publish-ontology-namespaces/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel
+- **[Story]**: Which user story this task belongs to
+
+---
+
+## Phase 1: Foundational
+
+- [ ] T001 Define the Turtle inputs and namespace mapping used to publish `/vocab/terms`, `/vocab/kinds`, `/vocab/groups`, and `/vocab/edges`.
+- [ ] T002 Implement a namespace-page generation step that reads Turtle-derived triples and emits namespace pages into a target output directory.
+- [ ] T003 Wire the namespace-page generation step into the build/deploy path so Pages artifacts contain `/vocab/...`.
+- [ ] T004 Document the reuse boundary so downstream graph-browser repos can publish their own ontology namespace pages from Turtle.
+
+## Phase 2: User Story 1 - Follow ontology terms from the viewer (P1)
+
+- [ ] T005 [US1] Ensure the viewer shows compact prefixed names and term/namespace links for ontology-backed nodes.
+- [ ] T006 [US1] Verify that nodes without ontology provenance do not show empty ontology identity UI.
+- [ ] T007 [US1] Verify locally that clicking graph-browser ontology term links resolves to generated namespace pages rather than 404s.
+
+## Phase 3: User Story 2 - Publish namespace pages automatically from Turtle (P1)
+
+- [ ] T008 [US2] Extract ontology term entries from Turtle using standard RDF/OWL predicates such as `rdf:type`, `rdfs:label`, and `dcterms:description`.
+- [ ] T009 [US2] Generate namespace pages for `terms`, `kinds`, `groups`, and `edges` with anchors matching the current ontology fragment identifiers.
+- [ ] T010 [US2] Include links from each namespace page to the underlying ontology artifacts under `dist/rdf`.
+- [ ] T011 [US2] Verify that the publication step does not require a hand-maintained per-project term inventory in source code.
+
+## Phase 4: User Story 3 - Reuse the publication path in the build/deploy workflow (P2)
+
+- [ ] T012 [US3] Update the Pages-style build flow to publish generated namespace pages automatically.
+- [ ] T013 [US3] Confirm the same generation path can be invoked by downstream repos that provide ontology Turtle files.
+- [ ] T014 [US3] Update [`README.md`](/code/graph-browser-issue-53/README.md) to document namespace publication policy, fragment behavior, and the Turtle-driven automation model.
+
+## Phase 5: Validation
+
+- [ ] T015 Run `nix develop -c just test`
+- [ ] T016 Run `nix build .#app`
+- [ ] T017 Run a local Pages-style build and verify `/vocab/terms`, `/vocab/kinds`, `/vocab/groups`, and `/vocab/edges` resolve correctly
+- [ ] T018 Confirm generated namespace pages come from Turtle-derived data rather than a hardcoded term list
+- [ ] T019 Update the PR description to explain the Turtle-driven namespace publication behavior once implementation is ready

--- a/specs/009-publish-ontology-namespaces/tasks.md
+++ b/specs/009-publish-ontology-namespaces/tasks.md
@@ -12,34 +12,34 @@
 
 ## Phase 1: Foundational
 
-- [ ] T001 Define the Turtle inputs and namespace mapping used to publish `/vocab/terms`, `/vocab/kinds`, `/vocab/groups`, and `/vocab/edges`.
-- [ ] T002 Implement a namespace-page generation step that reads Turtle-derived triples and emits namespace pages into a target output directory.
-- [ ] T003 Wire the namespace-page generation step into the build/deploy path so Pages artifacts contain `/vocab/...`.
-- [ ] T004 Document the reuse boundary so downstream graph-browser repos can publish their own ontology namespace pages from Turtle.
+- [x] T001 Define the Turtle inputs and namespace mapping used to publish `/vocab/terms`, `/vocab/kinds`, `/vocab/groups`, and `/vocab/edges`.
+- [x] T002 Implement a namespace-page generation step that reads Turtle-derived triples and emits namespace pages into a target output directory.
+- [x] T003 Wire the namespace-page generation step into the build/deploy path so Pages artifacts contain `/vocab/...`.
+- [x] T004 Document the reuse boundary so downstream graph-browser repos can publish their own ontology namespace pages from Turtle.
 
 ## Phase 2: User Story 1 - Follow ontology terms from the viewer (P1)
 
-- [ ] T005 [US1] Ensure the viewer shows compact prefixed names and term/namespace links for ontology-backed nodes.
-- [ ] T006 [US1] Verify that nodes without ontology provenance do not show empty ontology identity UI.
-- [ ] T007 [US1] Verify locally that clicking graph-browser ontology term links resolves to generated namespace pages rather than 404s.
+- [x] T005 [US1] Ensure the viewer shows compact prefixed names and term/namespace links for ontology-backed nodes.
+- [x] T006 [US1] Verify that nodes without ontology provenance do not show empty ontology identity UI.
+- [x] T007 [US1] Verify locally that clicking graph-browser ontology term links resolves to generated namespace pages rather than 404s.
 
 ## Phase 3: User Story 2 - Publish namespace pages automatically from Turtle (P1)
 
-- [ ] T008 [US2] Extract ontology term entries from Turtle using standard RDF/OWL predicates such as `rdf:type`, `rdfs:label`, and `dcterms:description`.
-- [ ] T009 [US2] Generate namespace pages for `terms`, `kinds`, `groups`, and `edges` with anchors matching the current ontology fragment identifiers.
-- [ ] T010 [US2] Include links from each namespace page to the underlying ontology artifacts under `dist/rdf`.
-- [ ] T011 [US2] Verify that the publication step does not require a hand-maintained per-project term inventory in source code.
+- [x] T008 [US2] Extract ontology term entries from Turtle using standard RDF/OWL predicates such as `rdf:type`, `rdfs:label`, and `dcterms:description`.
+- [x] T009 [US2] Generate namespace pages for `terms`, `kinds`, `groups`, and `edges` with anchors matching the current ontology fragment identifiers.
+- [x] T010 [US2] Include links from each namespace page to the underlying ontology artifacts under `dist/rdf`.
+- [x] T011 [US2] Verify that the publication step does not require a hand-maintained per-project term inventory in source code.
 
 ## Phase 4: User Story 3 - Reuse the publication path in the build/deploy workflow (P2)
 
-- [ ] T012 [US3] Update the Pages-style build flow to publish generated namespace pages automatically.
-- [ ] T013 [US3] Confirm the same generation path can be invoked by downstream repos that provide ontology Turtle files.
-- [ ] T014 [US3] Update [`README.md`](/code/graph-browser-issue-53/README.md) to document namespace publication policy, fragment behavior, and the Turtle-driven automation model.
+- [x] T012 [US3] Update the Pages-style build flow to publish generated namespace pages automatically.
+- [x] T013 [US3] Confirm the same generation path can be invoked by downstream repos that provide ontology Turtle files.
+- [x] T014 [US3] Update [`README.md`](/code/graph-browser-issue-53/README.md) to document namespace publication policy, fragment behavior, and the Turtle-driven automation model.
 
 ## Phase 5: Validation
 
-- [ ] T015 Run `nix develop -c just test`
-- [ ] T016 Run `nix build .#app`
-- [ ] T017 Run a local Pages-style build and verify `/vocab/terms`, `/vocab/kinds`, `/vocab/groups`, and `/vocab/edges` resolve correctly
-- [ ] T018 Confirm generated namespace pages come from Turtle-derived data rather than a hardcoded term list
+- [x] T015 Run `nix develop -c just test`
+- [x] T016 Run `nix build .#app`
+- [x] T017 Run a local Pages-style build and verify `/vocab/terms`, `/vocab/kinds`, `/vocab/groups`, and `/vocab/edges` resolve correctly
+- [x] T018 Confirm generated namespace pages come from Turtle-derived data rather than a hardcoded term list
 - [ ] T019 Update the PR description to explain the Turtle-driven namespace publication behavior once implementation is ready

--- a/src/Viewer.purs
+++ b/src/Viewer.purs
@@ -10,6 +10,8 @@ import Data.Map as Map
 import Data.Maybe (Maybe(..), isJust, isNothing)
 import Data.Set as Set
 import Data.String as String
+import Data.String.Common (joinWith, split)
+import Data.String.Pattern (Pattern(..))
 import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..))
 import Effect (Effect)
@@ -922,7 +924,7 @@ renderNodeDetail state node =
     [ HH.span
         [ cls ("badge badge-" <> node.kind) ]
         [ HH.text (kindLabel cfg node.kind) ]
-    , renderOntologyReference "Node ontology" node.ontologyRef
+    , renderOntologyIdentity node
     , HH.p [ cls "description" ]
         [ HH.text node.description ]
     , renderLinks node.links
@@ -957,6 +959,36 @@ renderNodeDetail state node =
           )
           links
       )
+
+  renderOntologyIdentity :: Node -> H.ComponentHTML Action () m
+  renderOntologyIdentity currentNode =
+    case ontologyIdentity currentNode of
+      Nothing -> HH.text ""
+      Just ident ->
+        HH.div [ cls "ontology-identity" ]
+          [ HH.div [ cls "connection-item" ]
+              [ HH.span [ cls "conn-label" ]
+                  [ HH.text "Ontology term" ]
+              , HH.a
+                  [ HP.href ident.iri
+                  , HP.target "_blank"
+                  , HP.rel "noopener"
+                  , cls "conn-node"
+                  ]
+                  [ HH.text ident.compact ]
+              ]
+          , HH.div [ cls "connection-item" ]
+              [ HH.span [ cls "conn-label" ]
+                  [ HH.text "Namespace" ]
+              , HH.a
+                  [ HP.href ident.namespace
+                  , HP.target "_blank"
+                  , HP.rel "noopener"
+                  , cls "conn-node"
+                  ]
+                  [ HH.text ident.namespaceLabel ]
+              ]
+          ]
 
   renderConnections
     :: String
@@ -1071,6 +1103,72 @@ renderLegend cfg =
           ]
           [ HH.text "Source" ]
     ]
+
+type OntologyIdentity =
+  { iri :: String
+  , compact :: String
+  , namespace :: String
+  , namespaceLabel :: String
+  }
+
+ontologyIdentity :: Node -> Maybe OntologyIdentity
+ontologyIdentity node = do
+  iri <- ontologyIri node
+  let
+    compact = compactIri iri
+    namespace = namespaceIri iri
+    namespaceLabel = namespaceName namespace
+  pure { iri, compact, namespace, namespaceLabel }
+
+ontologyIri :: Node -> Maybe String
+ontologyIri node = map _.iri node.ontologyRef
+
+compactIri :: String -> String
+compactIri iri =
+  case Array.find matchPrefix knownPrefixes of
+    Just (Tuple prefix namespace) ->
+      prefix <> ":" <> String.drop (String.length namespace) iri
+    Nothing -> iri
+  where
+  matchPrefix (Tuple _ namespace) =
+    String.take (String.length namespace) iri == namespace
+
+namespaceIri :: String -> String
+namespaceIri iri =
+  case Array.find matchPrefix knownPrefixes of
+    Just (Tuple _ namespace) -> namespace
+    Nothing ->
+      case String.lastIndexOf (Pattern "#") iri of
+        Just idx -> String.take (idx + 1) iri
+        Nothing ->
+          case split (Pattern "/") iri of
+            [] -> iri
+            parts ->
+              case Array.unsnoc parts of
+                Just { init } -> joinWith "/" init <> "/"
+                Nothing -> iri
+  where
+  matchPrefix (Tuple _ namespace) =
+    String.take (String.length namespace) iri == namespace
+
+namespaceName :: String -> String
+namespaceName namespace =
+  case Array.find (\(Tuple _ known) -> known == namespace) knownPrefixes of
+    Just (Tuple prefix _) -> prefix
+    Nothing -> namespace
+
+knownPrefixes :: Array (Tuple String String)
+knownPrefixes =
+  [ Tuple "owl" "http://www.w3.org/2002/07/owl#"
+  , Tuple "rdf" "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  , Tuple "rdfs" "http://www.w3.org/2000/01/rdf-schema#"
+  , Tuple "xsd" "http://www.w3.org/2001/XMLSchema#"
+  , Tuple "dcterms" "http://purl.org/dc/terms/"
+  , Tuple "gb" "https://lambdasistemi.github.io/graph-browser/vocab/terms#"
+  , Tuple "gbkind" "https://lambdasistemi.github.io/graph-browser/vocab/kinds#"
+  , Tuple "gbgroup" "https://lambdasistemi.github.io/graph-browser/vocab/groups#"
+  , Tuple "gbedge" "https://lambdasistemi.github.io/graph-browser/vocab/edges#"
+  ]
 
 handleAction
   :: forall o

--- a/src/Vocab/Publish/Main.purs
+++ b/src/Vocab/Publish/Main.purs
@@ -1,0 +1,435 @@
+module Vocab.Publish.Main where
+
+import Prelude
+
+import Control.Alt ((<|>))
+import Data.Array as Array
+import Data.Either (Either(..))
+import Data.Foldable (foldl)
+import Data.Map as Map
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.String as String
+import Data.String.Common (joinWith, split)
+import Data.String.Pattern (Pattern(..), Replacement(..))
+import Data.Traversable (sequence, traverse)
+import Data.Tuple (Tuple(..))
+import Effect (Effect)
+import Effect.Class.Console as Console
+import Effect.Exception (try)
+import FFI.Node as Node
+import FFI.Oxigraph as Oxigraph
+import FFI.Oxigraph (ImportedRdfQuad)
+import FFI.Uri (decodeUriComponent)
+
+type Options =
+  { outputDir :: String
+  , siteBasePath :: String
+  , sourcePaths :: Array String
+  }
+
+type NamespaceDocument =
+  { namespace :: String
+  , relativePath :: String
+  , title :: String
+  , sourceArtifacts :: Array String
+  , terms :: Array TermEntry
+  }
+
+type TermEntry =
+  { iri :: String
+  , fragment :: String
+  , compact :: String
+  , label :: String
+  , description :: String
+  , termType :: String
+  }
+
+rdfType :: String
+rdfType = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+
+rdfsLabel :: String
+rdfsLabel = "http://www.w3.org/2000/01/rdf-schema#label"
+
+rdfsComment :: String
+rdfsComment = "http://www.w3.org/2000/01/rdf-schema#comment"
+
+dctermsDescription :: String
+dctermsDescription = "http://purl.org/dc/terms/description"
+
+owlClass :: String
+owlClass = "http://www.w3.org/2002/07/owl#Class"
+
+owlObjectProperty :: String
+owlObjectProperty = "http://www.w3.org/2002/07/owl#ObjectProperty"
+
+owlDatatypeProperty :: String
+owlDatatypeProperty = "http://www.w3.org/2002/07/owl#DatatypeProperty"
+
+owlAnnotationProperty :: String
+owlAnnotationProperty = "http://www.w3.org/2002/07/owl#AnnotationProperty"
+
+rdfsClass :: String
+rdfsClass = "http://www.w3.org/2000/01/rdf-schema#Class"
+
+main :: Effect Unit
+main = do
+  args <- Node.getArgv
+  case parseOptions args of
+    Left err -> failWith err
+    Right options -> run options
+
+run :: Options -> Effect Unit
+run options = do
+  quadSets <- traverse loadSourceQuads options.sourcePaths
+  case sequence quadSets of
+    Left err -> failWith err
+    Right loaded -> do
+      let docs = namespaceDocuments options.siteBasePath options.sourcePaths (Array.concat loaded)
+      if Array.null docs then
+        failWith "No publishable ontology namespaces found in Turtle sources"
+      else do
+        _ <- traverse (writeNamespaceDocument options.outputDir) docs
+        Console.log ("Published ontology namespaces: " <> joinWith ", " (map _.relativePath docs))
+
+loadSourceQuads :: String -> Effect (Either String (Array ImportedRdfQuad))
+loadSourceQuads path = do
+  textResult <- tryReadTextFile path
+  case textResult of
+    Left _ -> pure (Left ("Failed to read ontology Turtle source: " <> path))
+    Right content -> do
+      parseResult <- try (Oxigraph.parseQuads "text/turtle" "https://graph-browser.invalid/" content)
+      pure case parseResult of
+        Left _ -> Left ("Failed to parse ontology Turtle source: " <> path)
+        Right quads -> Right quads
+
+namespaceDocuments :: String -> Array String -> Array ImportedRdfQuad -> Array NamespaceDocument
+namespaceDocuments siteBasePath sourcePaths quads =
+  mapMaybeNamespaceDocument grouped
+  where
+  grouped =
+    foldl
+      ( \acc iri ->
+          case namespaceKey siteBasePath iri of
+            Nothing -> acc
+            Just namespace ->
+              Map.alter
+                (Just <<< appendUnique iri <<< fromMaybe [])
+                namespace
+                acc
+      )
+      Map.empty
+      (publishableSubjects siteBasePath quads)
+
+  mapMaybeNamespaceDocument namespaces =
+    Array.mapMaybe
+      ( \(Tuple namespace iris) ->
+          let
+            entries = Array.sortBy compareTermEntries (map (termEntry quads namespace) iris)
+          in
+            if Array.null entries then
+              Nothing
+            else
+              Just
+                { namespace
+                , relativePath: namespaceRelativePath siteBasePath namespace
+                , title: namespaceTitle namespace
+                , sourceArtifacts: sourcePaths
+                , terms: entries
+                }
+      )
+      (Map.toUnfoldable namespaces :: Array (Tuple String (Array String)))
+
+publishableSubjects :: String -> Array ImportedRdfQuad -> Array String
+publishableSubjects siteBasePath quads =
+  Array.nub $ Array.mapMaybe publishableSubject quads
+  where
+  publishableSubject quad =
+    namespaceKey siteBasePath quad.subject *> pure quad.subject
+
+termEntry :: Array ImportedRdfQuad -> String -> String -> TermEntry
+termEntry quads namespace iri =
+  { iri
+  , fragment
+  , compact: compactName namespace fragment
+  , label: fromMaybe (fallbackLabel fragment) (literalValue quads iri rdfsLabel)
+  , description:
+      fromMaybe
+        ""
+        ( literalValue quads iri dctermsDescription
+            <|> literalValue quads iri rdfsComment
+        )
+  , termType: classifyTerm quads iri
+  }
+  where
+  fragment = String.drop (String.length namespace) iri
+
+classifyTerm :: Array ImportedRdfQuad -> String -> String
+classifyTerm quads iri =
+  if hasType owlClass then "owl:Class"
+  else if hasType rdfsClass then "rdfs:Class"
+  else if hasType owlObjectProperty then "owl:ObjectProperty"
+  else if hasType owlDatatypeProperty then "owl:DatatypeProperty"
+  else if hasType owlAnnotationProperty then "owl:AnnotationProperty"
+  else "term"
+  where
+  hasType typeIri =
+    Array.any
+      ( \quad ->
+          quad.subject == iri
+            && quad.predicate == rdfType
+            && quad.object.termType == "NamedNode"
+            && quad.object.value == typeIri
+      )
+      quads
+
+compactName :: String -> String -> String
+compactName namespace fragment =
+  namespacePrefix namespace <> ":" <> decodeOrOriginal fragment
+
+namespacePrefix :: String -> String
+namespacePrefix = namespaceTail
+
+namespaceTitle :: String -> String
+namespaceTitle namespace =
+  case namespaceTail namespace of
+    "terms" -> "Vocabulary Terms"
+    "kinds" -> "Vocabulary Kinds"
+    "groups" -> "Vocabulary Groups"
+    "edges" -> "Vocabulary Edges"
+    tailName -> "Vocabulary " <> tailName
+
+namespaceRelativePath :: String -> String -> String
+namespaceRelativePath siteBasePath namespace =
+  let path = namespacePath namespace
+      trimmedBase = normalizedBasePath siteBasePath
+      withoutBase =
+        if trimmedBase /= "" && String.take (String.length trimmedBase) path == trimmedBase then
+          String.drop (String.length trimmedBase) path
+        else
+          path
+      parts = Array.filter (_ /= "") (split (Pattern "/") withoutBase)
+  in joinWith "/" parts
+
+namespaceKey :: String -> String -> Maybe String
+namespaceKey siteBasePath iri = do
+  idx <- String.lastIndexOf (Pattern "#") iri
+  let namespace = String.take (idx + 1) iri
+      path = namespacePath namespace
+      base = normalizedBasePath siteBasePath
+  if isHttpNamespace namespace && isVocabPath base path then
+    Just namespace
+  else
+    Nothing
+
+namespacePath :: String -> String
+namespacePath namespace =
+  case String.indexOf (Pattern "://") withoutFragment of
+    Nothing -> namespace
+    Just schemeIdx ->
+      let
+        afterScheme = String.drop (schemeIdx + 3) withoutFragment
+      in
+        case String.indexOf (Pattern "/") afterScheme of
+          Nothing -> "/"
+          Just slashIdx -> "/" <> String.drop (slashIdx + 1) afterScheme
+  where
+  withoutFragment =
+    case String.lastIndexOf (Pattern "#") namespace of
+      Just idx -> String.take idx namespace
+      Nothing -> namespace
+
+normalizedBasePath :: String -> String
+normalizedBasePath base
+  | base == "" = ""
+  | String.take 1 base == "/" = trimTrailingSlash base
+  | otherwise = trimTrailingSlash ("/" <> base)
+
+trimTrailingSlash :: String -> String
+trimTrailingSlash value =
+  if String.length value > 1 && String.drop (String.length value - 1) value == "/" then
+    String.take (String.length value - 1) value
+  else
+    value
+
+isHttpNamespace :: String -> Boolean
+isHttpNamespace namespace =
+  String.take 7 namespace == "http://"
+    || String.take 8 namespace == "https://"
+
+isVocabPath :: String -> String -> Boolean
+isVocabPath base path
+  | base == "" = String.take 7 path == "/vocab/"
+  | otherwise =
+      let prefix = base <> "/vocab/"
+      in String.take (String.length prefix) path == prefix
+
+namespaceTail :: String -> String
+namespaceTail namespace =
+  let withoutHash =
+        case String.lastIndexOf (Pattern "#") namespace of
+          Just idx -> String.take idx namespace
+          Nothing -> namespace
+      pieces = Array.filter (_ /= "") (split (Pattern "/") withoutHash)
+  in fromMaybe namespace (Array.last pieces)
+
+fallbackLabel :: String -> String
+fallbackLabel fragment = decodeOrOriginal fragment
+
+decodeOrOriginal :: String -> String
+decodeOrOriginal value =
+  fromMaybe value (hushDecode value)
+
+hushDecode :: String -> Maybe String
+hushDecode value =
+  let decoded = decodeUriComponent value
+  in Just decoded
+
+literalValue :: Array ImportedRdfQuad -> String -> String -> Maybe String
+literalValue quads subject predicate =
+  Array.head
+    ( Array.mapMaybe
+        ( \quad ->
+            if
+              quad.subject == subject
+                && quad.predicate == predicate
+                && quad.object.termType == "Literal" then
+              Just quad.object.value
+            else
+              Nothing
+        )
+        quads
+    )
+
+appendUnique :: forall a. Eq a => a -> Array a -> Array a
+appendUnique item items =
+  if Array.elem item items then items else items <> [ item ]
+
+compareTermEntries :: TermEntry -> TermEntry -> Ordering
+compareTermEntries left right = compare left.fragment right.fragment
+
+writeNamespaceDocument :: String -> NamespaceDocument -> Effect Unit
+writeNamespaceDocument outputDir doc = do
+  targetDir <- Node.joinPath [ outputDir, doc.relativePath ]
+  targetPath <- Node.joinPath [ targetDir, "index.html" ]
+  Node.makeDirectory targetDir
+  Node.writeTextFile targetPath (renderNamespaceDocument doc)
+
+renderNamespaceDocument :: NamespaceDocument -> String
+renderNamespaceDocument doc =
+  joinWith "\n"
+    [ "<!doctype html>"
+    , "<html lang=\"en\">"
+    , "<head>"
+    , "  <meta charset=\"utf-8\">"
+    , "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
+    , "  <title>" <> escapeHtml doc.title <> "</title>"
+    , "  <style>"
+    , "    :root { color-scheme: dark; font-family: \"Iosevka Web\", \"IBM Plex Sans\", sans-serif; background: #10141c; color: #e8edf5; }"
+    , "    body { margin: 0; background: radial-gradient(circle at top left, #1d2633, #10141c 55%); }"
+    , "    main { max-width: 960px; margin: 0 auto; padding: 3rem 1.5rem 4rem; }"
+    , "    a { color: #8cc8ff; }"
+    , "    .meta { display: flex; flex-wrap: wrap; gap: 1rem; margin: 1rem 0 2rem; color: #b8c3d4; }"
+    , "    .term { border-top: 1px solid rgba(255,255,255,0.12); padding: 1rem 0 1.25rem; }"
+    , "    .term h2 { margin: 0 0 0.4rem; font-size: 1.1rem; }"
+    , "    code { background: rgba(255,255,255,0.08); padding: 0.15rem 0.35rem; border-radius: 0.3rem; }"
+    , "    .term-type { color: #ffcd7a; font-size: 0.95rem; }"
+    , "    .fragment { color: #b8c3d4; font-size: 0.92rem; }"
+    , "  </style>"
+    , "</head>"
+    , "<body>"
+    , "  <main>"
+    , "    <p><a href=\"../../docs/ontology/\">Ontology documentation</a></p>"
+    , "    <h1>" <> escapeHtml doc.title <> "</h1>"
+    , "    <p>This namespace document is generated automatically from ontology Turtle during the build.</p>"
+    , "    <div class=\"meta\">"
+    , "      <span>Namespace: <code>" <> escapeHtml doc.namespace <> "</code></span>"
+    , "      <span>Source TTL: " <> renderSourceArtifacts doc.sourceArtifacts <> "</span>"
+    , "    </div>"
+    , joinWith "\n" (map renderTermEntry doc.terms)
+    , "  </main>"
+    , "</body>"
+    , "</html>"
+    ]
+
+renderTermEntry :: TermEntry -> String
+renderTermEntry entry =
+  joinWith "\n"
+    [ "    <section class=\"term\" id=\"" <> escapeHtml entry.fragment <> "\">"
+    , "      <h2><code>" <> escapeHtml entry.compact <> "</code></h2>"
+    , "      <div class=\"fragment\">#" <> escapeHtml entry.fragment <> "</div>"
+    , "      <div class=\"term-type\">" <> escapeHtml entry.termType <> "</div>"
+    , "      <p><strong>" <> escapeHtml entry.label <> "</strong></p>"
+    , if entry.description == "" then "      <p>No description provided in the ontology.</p>"
+      else "      <p>" <> escapeHtml entry.description <> "</p>"
+    , "      <p><a href=\"" <> escapeHtml entry.iri <> "\">Term IRI</a></p>"
+    , "    </section>"
+    ]
+
+renderSourceArtifacts :: Array String -> String
+renderSourceArtifacts sourcePaths =
+  joinWith ", "
+    ( map
+        ( \path ->
+            let href = publishedArtifactHref path
+            in "<a href=\"" <> escapeHtml href <> "\">" <> escapeHtml href <> "</a>"
+        )
+        sourcePaths
+    )
+
+publishedArtifactHref :: String -> String
+publishedArtifactHref path =
+  if String.take 9 path == "data/rdf/" then
+    "../../rdf/" <> String.drop 9 path
+  else
+    path
+
+escapeHtml :: String -> String
+escapeHtml =
+  String.replaceAll (Pattern "&") (Replacement "&amp;")
+    >>> String.replaceAll (Pattern "<") (Replacement "&lt;")
+    >>> String.replaceAll (Pattern ">") (Replacement "&gt;")
+    >>> String.replaceAll (Pattern "\"") (Replacement "&quot;")
+
+tryReadTextFile :: String -> Effect (Either String String)
+tryReadTextFile path = do
+  result <- try (Node.readTextFile path)
+  pure case result of
+    Left _ -> Left path
+    Right text -> Right text
+
+parseOptions :: Array String -> Either String Options
+parseOptions = go
+  { outputDir: "dist"
+  , siteBasePath: "/graph-browser"
+  , sourcePaths:
+      [ "data/rdf/core-ontology.ttl"
+      , "data/rdf/application-ontology.ttl"
+      ]
+  }
+  where
+  go options remaining = case Array.uncons remaining of
+    Nothing -> Right options
+    Just { head: "--output-dir", tail } -> case Array.uncons tail of
+      Nothing -> Left "--output-dir requires a value"
+      Just { head: value, tail: rest } ->
+        go (options { outputDir = value }) rest
+    Just { head: "--site-base-path", tail } -> case Array.uncons tail of
+      Nothing -> Left "--site-base-path requires a value"
+      Just { head: value, tail: rest } ->
+        go (options { siteBasePath = value }) rest
+    Just { head: "--sources", tail } -> case Array.uncons tail of
+      Nothing -> Left "--sources requires a comma-separated value"
+      Just { head: value, tail: rest } ->
+        go
+          ( options
+              { sourcePaths = Array.filter (_ /= "") (split (Pattern ",") value)
+              }
+          )
+          rest
+    Just { head: arg } ->
+      Left ("Unknown argument: " <> arg)
+
+failWith :: String -> Effect Unit
+failWith message = do
+  Console.error message
+  Node.setExitCode 1

--- a/vocab-publish-action/action.yml
+++ b/vocab-publish-action/action.yml
@@ -1,0 +1,58 @@
+name: 'Publish Ontology Vocab Pages'
+description: 'Generate dereferenceable ontology namespace pages from Turtle files'
+
+inputs:
+  sources:
+    description: 'Comma-separated Turtle files to read'
+    required: false
+    default: 'data/rdf/core-ontology.ttl,data/rdf/application-ontology.ttl'
+  output-dir:
+    description: 'Directory containing the Pages artifact to update'
+    required: false
+    default: 'site'
+  site-base-path:
+    description: 'Base path to strip from namespace IRIs, such as /graph-browser for GitHub project Pages'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: paolino/dev-assets/setup-nix@v0.0.1
+
+    - name: Generate namespace pages
+      shell: bash
+      env:
+        SOURCE_PATHS: ${{ inputs.sources }}
+        OUTPUT_DIR: ${{ inputs.output-dir }}
+        SITE_BASE_PATH: ${{ inputs.site-base-path }}
+      run: |
+        set -euo pipefail
+
+        ACTION_DIR="$GITHUB_ACTION_PATH"
+        WORKSPACE_DIR="$GITHUB_WORKSPACE"
+
+        absolutize() {
+          case "$1" in
+            /*) printf '%s' "$1" ;;
+            *) printf '%s/%s' "$WORKSPACE_DIR" "$1" ;;
+          esac
+        }
+
+        IFS=',' read -r -a source_parts <<< "$SOURCE_PATHS"
+        abs_sources=()
+        for source in "${source_parts[@]}"; do
+          [ -z "$source" ] && continue
+          abs_sources+=("$(absolutize "$source")")
+        done
+
+        sources_csv=$(IFS=','; echo "${abs_sources[*]}")
+        output_dir="$(absolutize "$OUTPUT_DIR")"
+
+        cd "$ACTION_DIR"
+        npm ci
+        NODE_OPTIONS="--require ./src/oxigraph-shim.cjs" \
+          nix develop --quiet -c spago run --main Vocab.Publish.Main -- \
+            --output-dir "$output_dir" \
+            --site-base-path "$SITE_BASE_PATH" \
+            --sources "$sources_csv"


### PR DESCRIPTION
Closes #53

## Summary

Adds a Turtle-driven namespace publication path for graph-browser ontology vocabularies.

This branch generates dereferenceable namespace pages from ontology Turtle rather than maintaining a hardcoded vocabulary catalog. The Pages build emits `/vocab/terms`, `/vocab/kinds`, `/vocab/groups`, and `/vocab/edges` into `dist/`, and a reusable `vocab-publish-action` wrapper exposes the same PureScript-backed generator for downstream repositories.

## Verification

- `nix develop -c spago build`
- `nix develop -c just build-docs`
- action-style absolute-path generator invocation into `/tmp/gb-vocab-test`
- `nix develop -c just test`
- `nix build .#app`
- local full Pages artifact build
- temporary PR build-preview experiment passed, then the temporary PR trigger patch was removed before merge

## Preview

Surge preview for the generated Pages artifact:

- https://graph-browser-vocab-pr59-ba275d8.surge.sh
- https://graph-browser-vocab-pr59-ba275d8.surge.sh/vocab/terms/
- https://graph-browser-vocab-pr59-ba275d8.surge.sh/vocab/kinds/
- https://graph-browser-vocab-pr59-ba275d8.surge.sh/vocab/groups/
- https://graph-browser-vocab-pr59-ba275d8.surge.sh/vocab/edges/
