### PR TITLE
fix: use absolute path for oxigraph-shim in vocab-publish-action

### DIFF
--- a/vocab-publish-action/action.yml
+++ b/vocab-publish-action/action.yml
@@ -51,7 +51,7 @@ runs:
 
         cd "$ACTION_DIR"
         npm ci
-        NODE_OPTIONS="--require ./src/oxigraph-shim.cjs" \
+        NODE_OPTIONS="--require $ACTION_DIR/src/oxigraph-shim.cjs" \
           nix develop --quiet -c spago run --main Vocab.Publish.Main -- \
             --output-dir "$output_dir" \
             --site-base-path "$SITE_BASE_PATH" \


### PR DESCRIPTION
The `--require ./src/oxigraph-shim.cjs` path in vocab-publish-action resolves relative to the node process cwd, which can change when `nix develop` runs. This causes `Cannot find module './src/oxigraph-shim.cjs'` when the action is used from downstream repos.

Fix: use `$ACTION_DIR/src/oxigraph-shim.cjs` (absolute path).

Failed run: https://github.com/lambdasistemi/cardano-knowledge-maps/actions/runs/24234632125