### PR TITLE
fix: resolve oxigraph-shim from repo root in vocab-publish-action

### DIFF
--- a/vocab-publish-action/action.yml
+++ b/vocab-publish-action/action.yml
@@ -49,9 +49,10 @@ runs:
         sources_csv=$(IFS=','; echo "${abs_sources[*]}")
         output_dir="$(absolutize "$OUTPUT_DIR")"
 
+        REPO_ROOT="$(cd "$ACTION_DIR/.." && pwd)"
         cd "$ACTION_DIR"
         npm ci
-        NODE_OPTIONS="--require $ACTION_DIR/src/oxigraph-shim.cjs" \
+        NODE_OPTIONS="--require $REPO_ROOT/src/oxigraph-shim.cjs" \
           nix develop --quiet -c spago run --main Vocab.Publish.Main -- \
             --output-dir "$output_dir" \
             --site-base-path "$SITE_BASE_PATH" \


### PR DESCRIPTION
Follow-up to #60 — `GITHUB_ACTION_PATH` points to `vocab-publish-action/` but `oxigraph-shim.cjs` lives at `src/` relative to the repo root.

Fix: resolve `$REPO_ROOT` as `$ACTION_DIR/..` and use `$REPO_ROOT/src/oxigraph-shim.cjs`.

Failed downstream run: https://github.com/lambdasistemi/cardano-knowledge-maps/actions/runs/24235024300