### PR TITLE
feat: ?branch= URL param for non-main data (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,12 @@ No build tools needed — the actions download the app and assemble the site.
 
 Visit `https://lambdasistemi.github.io/graph-browser/?repo=owner/repo` to browse any repo with a `data/` directory.
 
+Supported URL parameters:
+
+- `?repo=owner/repo` — the data repository to load.
+- `?branch=<ref>` — load `data/` from a non-`main` git ref (branch, tag, or commit SHA) via raw GitHub URLs. Without this parameter the viewer tries `main`, then `master`. Useful for previewing in-progress work before merge.
+- `?theme=light|dark|auto` — force a colour palette or follow the OS preference.
+
 ### Option 3: Use as a Nix flake input
 
 ```nix
@@ -226,7 +232,7 @@ Add `.graph-browser.json` to your repo root to customize data paths:
 }
 ```
 
-Without a manifest, the app looks for `data/` on the repo's main branch via raw GitHub URLs.
+Without a manifest, the app looks for `data/` on the repo's main branch via raw GitHub URLs. When `?branch=<ref>` is set, the manifest and the `data/` fallback are both resolved against that ref.
 
 ## Development
 

--- a/src/FFI/Url.js
+++ b/src/FFI/Url.js
@@ -29,3 +29,19 @@ export const setViewParam = (view) => () => {
   }
   history.replaceState(null, "", url);
 };
+
+export const getBranchParam = () => {
+  var params = new URLSearchParams(window.location.search);
+  var branch = params.get("branch");
+  return branch || "";
+};
+
+export const setBranchParam = (branch) => () => {
+  var url = new URL(window.location);
+  if (branch === "") {
+    url.searchParams.delete("branch");
+  } else {
+    url.searchParams.set("branch", branch);
+  }
+  history.replaceState(null, "", url);
+};

--- a/src/FFI/Url.purs
+++ b/src/FFI/Url.purs
@@ -3,6 +3,8 @@ module FFI.Url
   , setRepoParam
   , getViewParam
   , setViewParam
+  , getBranchParam
+  , setBranchParam
   ) where
 
 import Prelude
@@ -16,3 +18,7 @@ foreign import setRepoParam :: String -> Effect Unit
 foreign import getViewParam :: Effect String
 
 foreign import setViewParam :: String -> Effect Unit
+
+foreign import getBranchParam :: Effect String
+
+foreign import setBranchParam :: String -> Effect Unit

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -44,6 +44,7 @@ type AppState =
   { repos :: Array Persist.RepoListEntry
   , activeRepo :: Maybe Persist.RepoListEntry
   , dataUrls :: Maybe Viewer.DataUrls
+  , branch :: Maybe String
   , loading :: Boolean
   }
 
@@ -58,6 +59,7 @@ appComponent = H.mkComponent
       { repos: []
       , activeRepo: Nothing
       , dataUrls: Nothing
+      , branch: Nothing
       , loading: false
       }
   , render: appRender
@@ -94,7 +96,10 @@ appHandleAction = case _ of
   AppInit -> do
     liftEffect Resize.initResize
     repos <- liftEffect Persist.loadRepoList
-    H.modify_ _ { repos = repos }
+    -- Capture ?branch= once at startup so the whole session uses it
+    branchParam <- liftEffect Url.getBranchParam
+    let mBranch = if branchParam == "" then Nothing else Just branchParam
+    H.modify_ _ { repos = repos, branch = mBranch }
     void $ H.tell _repoManager unit
       (RM.SetRepos repos)
     -- Check for ?repo= deep link
@@ -118,7 +123,9 @@ appHandleAction = case _ of
           H.modify_ _ { loading = true }
           void $ H.tell _repoManager unit
             (RM.SetError Nothing)
-          result <- liftAff (RD.discoverDataUrls src)
+          mBranch <- H.gets _.branch
+          result <- liftAff
+            (RD.discoverDataUrlsAuth Nothing mBranch src)
           case result of
             Left err -> do
               H.modify_ _ { loading = false }
@@ -179,6 +186,8 @@ appHandleAction = case _ of
         void $ H.tell _repoManager unit
           (RM.SetActive Nothing)
         liftEffect $ Url.setRepoParam ""
+        liftEffect $ Url.setBranchParam ""
+        H.modify_ _ { branch = Nothing }
 
     RM.ClearAll -> do
       state <- H.get
@@ -189,12 +198,14 @@ appHandleAction = case _ of
         { repos = []
         , activeRepo = Nothing
         , dataUrls = Nothing
+        , branch = Nothing
         }
       void $ H.tell _repoManager unit
         (RM.SetRepos [])
       void $ H.tell _repoManager unit
         (RM.SetActive Nothing)
       liftEffect $ Url.setRepoParam ""
+      liftEffect $ Url.setBranchParam ""
 
 selectRepo
   :: forall o
@@ -204,7 +215,9 @@ selectRepo entry = do
   case RD.normalizeInput entry.id of
     Nothing -> pure unit
     Just src -> do
-      result <- liftAff (RD.discoverDataUrls src)
+      mBranch <- H.gets _.branch
+      result <- liftAff
+        (RD.discoverDataUrlsAuth Nothing mBranch src)
       case result of
         Left _ -> pure unit
         Right urls -> do
@@ -215,6 +228,9 @@ selectRepo entry = do
           void $ H.tell _repoManager unit
             (RM.SetActive (Just entry.id))
           liftEffect $ Url.setRepoParam entry.id
+          case mBranch of
+            Just b -> liftEffect $ Url.setBranchParam b
+            Nothing -> liftEffect $ Url.setBranchParam ""
 
 -- Helpers
 

--- a/src/RepoDiscovery.purs
+++ b/src/RepoDiscovery.purs
@@ -84,14 +84,31 @@ mkRepoSource owner repo =
 -- | Tries manifest first (main then master branch),
 -- | falls back to convention data/ paths on GitHub Pages.
 discoverDataUrls :: RepoSource -> Aff (Either String DataUrls)
-discoverDataUrls = discoverDataUrlsAuth Nothing
+discoverDataUrls src = discoverDataUrlsAuth Nothing Nothing src
 
--- | Discover with optional auth token.
+-- | Discover with optional auth token and optional branch override.
+-- | When a branch is given, only that branch is tried (no main/master
+-- | fallback). Without a branch, tries main, then master, then
+-- | convention URLs on main.
 discoverDataUrlsAuth
   :: Maybe String
+  -> Maybe String
   -> RepoSource
   -> Aff (Either String DataUrls)
-discoverDataUrlsAuth mToken src = do
+discoverDataUrlsAuth mToken (Just branch) src = do
+  let rawBranch = src.rawBaseUrl <> "/" <> branch <> "/"
+  manifestResult <- tryFetchManifest mToken rawBranch
+    (rawBranch <> ".graph-browser.json")
+  case manifestResult of
+    Right urls -> pure (Right urls)
+    Left _ -> do
+      let urls = conventionUrlsAt rawBranch
+      reachable <- tryFetchUrl mToken urls.configUrl
+      if reachable then pure (Right urls)
+      else pure (Left
+        ("No graph data found on branch '" <> branch
+          <> "'. Add data/ directory or .graph-browser.json to that branch"))
+discoverDataUrlsAuth mToken Nothing src = do
   let rawMain = src.rawBaseUrl <> "/main/"
   let rawMaster = src.rawBaseUrl <> "/master/"
   mainResult <- tryFetchManifest mToken rawMain
@@ -156,14 +173,16 @@ parseManifest base body =
 -- | Convention-based URLs when no manifest exists.
 -- | Uses raw GitHub URLs so data/ works without GitHub Pages.
 conventionUrls :: RepoSource -> DataUrls
-conventionUrls src =
-  let raw = src.rawBaseUrl <> "/main/"
-  in
-    { configUrl: raw <> "data/config.json"
-    , graphUrl: raw <> "data/graph.json"
-    , tutorialIndexUrl: raw <> "data/tutorials/index.json"
-    , baseUrl: raw
-    }
+conventionUrls src = conventionUrlsAt (src.rawBaseUrl <> "/main/")
+
+-- | Convention URLs rooted at an arbitrary raw base (any branch).
+conventionUrlsAt :: String -> DataUrls
+conventionUrlsAt raw =
+  { configUrl: raw <> "data/config.json"
+  , graphUrl: raw <> "data/graph.json"
+  , tutorialIndexUrl: raw <> "data/tutorials/index.json"
+  , baseUrl: raw
+  }
 
 -- | Check if a URL is reachable (returns 2xx).
 tryFetchUrl :: Maybe String -> String -> Aff Boolean


### PR DESCRIPTION
Closes #36.

## Summary

Add an optional `?branch=<ref>` URL parameter so the universal viewer can load `data/` from a feature branch, tag, or commit SHA via raw GitHub URLs. Without the parameter the existing `main` → `master` → convention fallback is preserved.

## Changes

- **`src/FFI/Url.{js,purs}`** — new `getBranchParam` / `setBranchParam`, matching the existing `repo` / `view` / `theme` pair.
- **`src/RepoDiscovery.purs`** — `discoverDataUrlsAuth` gains a `Maybe String` branch argument. When `Just branch`, only that ref is tried: manifest (`<raw>/<branch>/.graph-browser.json`) first, then the `data/*` convention at the same ref. No cross-branch fallback in that mode. `conventionUrls` now delegates to a new `conventionUrlsAt :: String -> DataUrls` helper so both default (`/main/`) and arbitrary branches share one path builder.
- **`src/Main.purs`** — captures `?branch=` once at `AppInit` into `AppState.branch` and threads it through `RepoAdded` and `selectRepo`. The param is round-tripped via `setBranchParam` on repo selection and cleared alongside `?repo=` on `RepoDeleted` (when the active repo is removed) and `ClearAll`.
- **`README.md`** — documents the parameter and how it interacts with manifest discovery.

## Why `Maybe String` instead of mangling `main` into the default path

Keeping the default path `main/` → `master/` → convention untouched means existing shareable links and the `rawMain`/`rawMaster` probing behaviour don't change. A branch override is an *explicit* choice by the link author, and when they make that choice we skip probing entirely — falling back to `main` after a failed `feat/foo` fetch would silently mask user error.

## Acceptance criteria

- [x] `?branch=<ref>` loads `data/` from that ref via raw GitHub URLs
- [x] Absent parameter falls back to `main` (current behavior preserved)
- [x] Parameter round-trips through URL on navigation so links are shareable
- [x] Works in combination with `?repo=` (compatible with `?view=` once #68 lands)
- [x] Manifest / config / graph all resolve against the selected ref
- [x] Documented in README

## Test plan

- [x] `nix develop -c just ci` — 26/26 tests pass, build and bundle succeed.
- [ ] Manual: `https://lambdasistemi.github.io/graph-browser/?repo=lambdasistemi/graph-browser&branch=feat/branch-param` loads `data/` from this branch after Pages deploys.
- [ ] Manual: `?branch=nonexistent` surfaces a clear error instead of silently falling back to `main`.