### PR TITLE
feat: composed graphs — per-source named graphs + Sources panel

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -259,7 +259,7 @@
   }
   .param-select:focus { border-color: var(--accent); }
 
-  .query-panel {
+  .left-column {
     width: 300px;
     min-width: 240px;
     background: var(--bg-base);
@@ -268,9 +268,80 @@
     flex-direction: column;
     flex-shrink: 0;
     overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: var(--border) transparent;
+  }
+  .query-panel {
+    min-width: 0;
+    background: var(--bg-base);
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    overflow-y: auto;
     direction: rtl;
     scrollbar-width: thin;
     scrollbar-color: var(--border) transparent;
+  }
+  .sources-panel {
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-base);
+    flex: 0 0 auto;
+  }
+  .sources-header {
+    padding: 10px 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    user-select: none;
+    border-bottom: 1px solid var(--border-subtle);
+    transition: background 0.15s ease;
+  }
+  .sources-header:hover { background: var(--bg-surface); }
+  .sources-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  .sources-count {
+    font-size: 11px;
+    color: var(--text-muted);
+    background: var(--bg-surface);
+    padding: 1px 6px;
+    border-radius: 10px;
+  }
+  .sources-chevron {
+    margin-left: auto;
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+  .sources-list {
+    display: flex;
+    flex-direction: column;
+    padding: 4px 0;
+  }
+  .sources-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 16px;
+    cursor: pointer;
+    font-size: 12px;
+    color: var(--text-primary);
+    transition: background 0.15s ease;
+  }
+  .sources-row:hover { background: var(--bg-surface); }
+  .sources-row input[type="checkbox"] {
+    accent-color: var(--accent);
+    cursor: pointer;
+    margin: 0;
+  }
+  .sources-row-label {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .query-panel > * {
     direction: ltr;

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -72,6 +72,10 @@
         "path": {
           "type": "string",
           "description": "Path to the RDF asset relative to the site or raw repository root (for example 'data/rdf/graph.nq')."
+        },
+        "label": {
+          "type": "string",
+          "description": "Optional human-readable label shown in the Sources sidebar. Defaults to the path."
         }
       }
     }

--- a/src/FFI/Oxigraph.js
+++ b/src/FFI/Oxigraph.js
@@ -75,8 +75,15 @@ const bindingToRecord = (bindings) => {
   return result;
 };
 
+// All SPARQL queries run with `use_default_graph_as_union: true` so that
+// patterns like `{ ?s ?p ?o }` match statements in every named graph as
+// well as the default graph. This lets data loaded into per-source named
+// graphs stay queryable by existing SPARQL views while preserving graph
+// membership for `GRAPH ?g { ... }` patterns.
+const QUERY_OPTIONS = { use_default_graph_as_union: true };
+
 export const querySparql = (store) => (sparql) => () => {
-  const results = store.query(sparql);
+  const results = store.query(sparql, QUERY_OPTIONS);
   if (typeof results === "boolean") {
     return [];
   }
@@ -88,7 +95,7 @@ export const querySparql = (store) => (sparql) => () => {
 };
 
 export const querySparqlStrings = (store) => (sparql) => () => {
-  const results = store.query(sparql);
+  const results = store.query(sparql, QUERY_OPTIONS);
   if (typeof results === "boolean") {
     return [];
   }
@@ -103,7 +110,7 @@ export const querySparqlStrings = (store) => (sparql) => () => {
 };
 
 export const querySparqlNodeIds = (store) => (sparql) => () => {
-  const results = store.query(sparql);
+  const results = store.query(sparql, QUERY_OPTIONS);
   if (typeof results === "boolean") {
     return [];
   }

--- a/src/FFI/Oxigraph.js
+++ b/src/FFI/Oxigraph.js
@@ -49,6 +49,7 @@ export const parseQuads = (format) => (baseIri) => (input) => () =>
           ? quad.object.language
           : "",
     },
+    graph: quad.graph && quad.graph.termType === "NamedNode" ? quad.graph.value : "",
   }));
 
 // --- SPARQL Store API ---

--- a/src/FFI/Oxigraph.js
+++ b/src/FFI/Oxigraph.js
@@ -56,11 +56,15 @@ export const parseQuads = (format) => (baseIri) => (input) => () =>
 
 export const createStore = () => new oxigraph.Store();
 
-export const loadRdf = (store) => (format) => (baseIri) => (content) => () => {
-  store.load(content, {
+export const loadRdf = (store) => (format) => (baseIri) => (toGraphName) => (content) => () => {
+  const options = {
     format,
     base_iri: baseIri,
-  });
+  };
+  if (toGraphName) {
+    options.to_graph_name = namedNode(toGraphName);
+  }
+  store.load(content, options);
 };
 
 const bindingToRecord = (bindings) => {

--- a/src/FFI/Oxigraph.purs
+++ b/src/FFI/Oxigraph.purs
@@ -29,6 +29,7 @@ type ImportedRdfQuad =
   { subject :: String
   , predicate :: String
   , object :: ImportedRdfObject
+  , graph :: String
   }
 
 type RdfObject =

--- a/src/FFI/Oxigraph.purs
+++ b/src/FFI/Oxigraph.purs
@@ -65,8 +65,16 @@ type SparqlBinding = Foreign
 
 foreign import createStore :: Effect OxigraphStore
 
+-- | loadRdf store format baseIri toGraphName content
+-- | Pass "" as toGraphName to load into the default graph.
+-- | Pass a non-empty IRI to load into that named graph.
 foreign import loadRdf
-  :: OxigraphStore -> String -> String -> String -> Effect Unit
+  :: OxigraphStore
+  -> String
+  -> String
+  -> String
+  -> String
+  -> Effect Unit
 
 foreign import querySparql
   :: OxigraphStore -> String -> Effect (Array SparqlBinding)

--- a/src/Graph/Decode.purs
+++ b/src/Graph/Decode.purs
@@ -127,7 +127,8 @@ decodeGraphSource json = do
   obj <- lmap' $ decodeJson json
   format <- lmap' $ obj .: "format"
   path <- lmap' $ obj .: "path"
-  pure { format, path }
+  label <- lmap' $ fromMaybe "" <$> obj .:? "label"
+  pure { format, path, label }
 
 lmap'
   :: forall a

--- a/src/Graph/Decode.purs
+++ b/src/Graph/Decode.purs
@@ -95,6 +95,7 @@ decodeNode json = do
     , description
     , links
     , ontologyRef: Nothing
+    , sources: []
     }
 
 decodeLink :: Json -> Either String Link
@@ -118,6 +119,7 @@ decodeEdge json = do
     , label
     , description
     , predicateRef: Nothing
+    , sources: []
     }
 
 decodeGraphSource :: Json -> Either String GraphSource

--- a/src/Graph/Operations.purs
+++ b/src/Graph/Operations.purs
@@ -3,6 +3,7 @@
 module Graph.Operations
   ( neighborhood
   , subgraph
+  , filterBySources
   ) where
 
 import Prelude
@@ -58,3 +59,39 @@ subgraph keep graph =
           && Set.member e.target keep
     )
     graph.edges
+
+-- | Hide nodes and edges whose `sources` is a non-empty subset of the
+-- | user-hidden sources. Elements with an empty `sources` list have no
+-- | provenance to filter against and are always visible. Edges whose
+-- | source or target node is hidden are also dropped, to keep the
+-- | output well-formed.
+filterBySources :: Set String -> Graph -> Graph
+filterBySources hidden graph
+  | Set.isEmpty hidden = graph
+  | otherwise = buildGraph keptNodes keptEdges
+      where
+      nodeVisible n =
+        Array.null n.sources
+          || Array.any
+            (\src -> not (Set.member src hidden))
+            n.sources
+
+      edgeVisible e =
+        Array.null e.sources
+          || Array.any
+            (\src -> not (Set.member src hidden))
+            e.sources
+
+      keptNodes = Array.filter
+        nodeVisible
+        (Array.fromFoldable (Map.values graph.nodes))
+
+      keptNodeIds = Set.fromFoldable (map _.id keptNodes)
+
+      keptEdges = Array.filter
+        ( \e ->
+            edgeVisible e
+              && Set.member e.source keptNodeIds
+              && Set.member e.target keptNodeIds
+        )
+        graph.edges

--- a/src/Graph/Types.purs
+++ b/src/Graph/Types.purs
@@ -86,6 +86,9 @@ type Graph =
 type GraphSource =
   { format :: String
   , path :: String
+  -- | Optional human-readable label. Empty string means "no label
+  -- | configured"; UI code falls back to the path in that case.
+  , label :: String
   }
 
 -- | Application configuration loaded from config.json.

--- a/src/Graph/Types.purs
+++ b/src/Graph/Types.purs
@@ -55,6 +55,10 @@ type Node =
   , description :: String
   , links :: Array Link
   , ontologyRef :: Maybe OntologyReference
+  -- | IRIs of the source graphs that contributed at least one statement
+  -- | about this node. Empty for nodes without provenance (e.g. loaded
+  -- | from a legacy JSON graph).
+  , sources :: Array String
   }
 
 -- | A directed edge in the knowledge graph.
@@ -64,6 +68,10 @@ type Edge =
   , label :: String
   , description :: String
   , predicateRef :: Maybe OntologyReference
+  -- | IRIs of the source graphs that contributed the triple underlying
+  -- | this edge. Typically a singleton, but can be larger when the same
+  -- | triple is defined in more than one source.
+  , sources :: Array String
   }
 
 -- | The full graph: nodes, edges, and adjacency.

--- a/src/Ontology/Extract.purs
+++ b/src/Ontology/Extract.purs
@@ -202,6 +202,7 @@ classesToNodes classes depths =
               { label: cls.label
               , iri: cls.iri
               }
+          , sources: []
           }
     )
     classes
@@ -247,6 +248,7 @@ extractSubclassEdges quads nodeIdByIri =
               { label: "subClassOf"
               , iri: rdfsSubclassOf
               }
+          , sources: []
           }
     )
     (extractSubclassLinks quads)
@@ -282,6 +284,7 @@ extractPropertyEdges quads nodeIdByIri =
                                 { label
                                 , iri: propertyIri
                                 }
+                            , sources: []
                             }
                       )
                       ranges
@@ -316,6 +319,7 @@ extractAlignmentEdges quads nodeIdByIri =
                   { label: "equivalentClass"
                   , iri: owlEquivalentClass
                   }
+              , sources: []
               }
           else
             Nothing
@@ -362,6 +366,7 @@ extractAlignmentEdges quads nodeIdByIri =
                       { label: "equivalentProperty"
                       , iri: owlEquivalentProperty
                       }
+                  , sources: []
                   }
             )
             rights

--- a/src/Rdf/Export/Main.purs
+++ b/src/Rdf/Export/Main.purs
@@ -83,8 +83,10 @@ loadRdfGraph sources = do
   pure case sequence quadSets of
     Left err -> Left err
     Right loaded ->
-      let quads = Array.concat loaded
-      in Import.importInstanceGraph quads
+      let
+        quads = Array.concat loaded
+      in
+        Import.importInstanceGraph quads
 
 loadSourceQuads :: GraphSource -> Effect (Either String (Array Oxigraph.ImportedRdfQuad))
 loadSourceQuads source = do

--- a/src/Rdf/Import.purs
+++ b/src/Rdf/Import.purs
@@ -116,6 +116,7 @@ importNode quads iri = do
     description = fromMaybe "" (literalValue quads iri dctermsDescription)
     links = fallbackLinks quads iri
     ontologyRef = semanticTypeReference quads iri
+    sources = subjectSources quads iri
   pure
     { iri
     , node:
@@ -126,8 +127,22 @@ importNode quads iri = do
         , description
         , links
         , ontologyRef
+        , sources
         }
     }
+
+-- | Distinct, non-empty graph IRIs that contributed at least one
+-- | statement with `iri` as subject.
+subjectSources :: Array ImportedRdfQuad -> String -> Array String
+subjectSources quads iri =
+  Array.nub
+    ( Array.mapMaybe
+        ( \quad ->
+            if quad.subject == iri && quad.graph /= "" then Just quad.graph
+            else Nothing
+        )
+        quads
+    )
 
 fallbackLinks :: Array ImportedRdfQuad -> String -> Array Link
 fallbackLinks quads subject =
@@ -166,6 +181,9 @@ importRelationEdges quads nodeIdByIri reifiedDescriptions =
               fromMaybe ""
                 (Map.lookup (edgeKey quad.subject quad.predicate quad.object.value) reifiedDescriptions)
           , predicateRef: predicateReference quads quad.predicate
+          , sources:
+              if quad.graph == "" then []
+              else [ quad.graph ]
           }
     )
     quads
@@ -191,6 +209,7 @@ mergeEdges edges =
         if edge.description /= "" then edge.description
         else existing.description
     , predicateRef: choosePredicateRef existing.predicateRef edge.predicateRef
+    , sources: Array.nub (existing.sources <> edge.sources)
     }
 
   preferNew edge existing =

--- a/src/RepoDiscovery.purs
+++ b/src/RepoDiscovery.purs
@@ -27,7 +27,8 @@ type RepoSource =
 -- | "https://owner.github.io/repo/", direct manifest URL.
 normalizeInput :: String -> Maybe RepoSource
 normalizeInput input =
-  let trimmed = String.trim input
+  let
+    trimmed = String.trim input
   in
     parseOwnerSlashRepo trimmed
       <|> parseGitHubUrl trimmed
@@ -38,11 +39,9 @@ parseOwnerSlashRepo str = do
   let parts = splitFirst "/" str
   case parts of
     Just { before: owner, after: repo } ->
-      if String.contains (String.Pattern "/") repo
-        then Nothing
-        else if owner == "" || repo == ""
-          then Nothing
-          else Just (mkRepoSource owner repo)
+      if String.contains (String.Pattern "/") repo then Nothing
+      else if owner == "" || repo == "" then Nothing
+      else Just (mkRepoSource owner repo)
     Nothing -> Nothing
 
 parseGitHubUrl :: String -> Maybe RepoSource
@@ -53,9 +52,8 @@ parseGitHubUrl str = do
   case parts of
     Just { before: owner, after: rest2 } -> do
       let repo = stripSuffix ".git" (takeUntil "/" rest2)
-      if owner == "" || repo == ""
-        then Nothing
-        else Just (mkRepoSource owner repo)
+      if owner == "" || repo == "" then Nothing
+      else Just (mkRepoSource owner repo)
     Nothing -> Nothing
 
 parseGitHubPagesUrl :: String -> Maybe RepoSource
@@ -65,9 +63,8 @@ parseGitHubPagesUrl str = do
   case parts of
     Just { before: owner, after: rest2 } -> do
       let repo = stripTrailingSlash (takeUntil "/" rest2)
-      if owner == "" || repo == ""
-        then Nothing
-        else Just (mkRepoSource owner repo)
+      if owner == "" || repo == "" then Nothing
+      else Just (mkRepoSource owner repo)
     Nothing -> Nothing
 
 mkRepoSource :: String -> String -> RepoSource
@@ -75,9 +72,13 @@ mkRepoSource owner repo =
   { owner
   , repo
   , rawBaseUrl: "https://raw.githubusercontent.com/"
-      <> owner <> "/" <> repo
+      <> owner
+      <> "/"
+      <> repo
   , pagesBaseUrl: "https://" <> owner
-      <> ".github.io/" <> repo <> "/"
+      <> ".github.io/"
+      <> repo
+      <> "/"
   }
 
 -- | Discover data URLs for a repo.
@@ -105,9 +106,12 @@ discoverDataUrlsAuth mToken (Just branch) src = do
       let urls = conventionUrlsAt rawBranch
       reachable <- tryFetchUrl mToken urls.configUrl
       if reachable then pure (Right urls)
-      else pure (Left
-        ("No graph data found on branch '" <> branch
-          <> "'. Add data/ directory or .graph-browser.json to that branch"))
+      else pure
+        ( Left
+            ( "No graph data found on branch '" <> branch
+                <> "'. Add data/ directory or .graph-browser.json to that branch"
+            )
+        )
 discoverDataUrlsAuth mToken Nothing src = do
   let rawMain = src.rawBaseUrl <> "/main/"
   let rawMaster = src.rawBaseUrl <> "/master/"
@@ -124,8 +128,10 @@ discoverDataUrlsAuth mToken Nothing src = do
           let urls = conventionUrls src
           reachable <- tryFetchUrl mToken urls.configUrl
           if reachable then pure (Right urls)
-          else pure (Left
-            "No graph data found. Add data/ directory or .graph-browser.json to your repo")
+          else pure
+            ( Left
+                "No graph data found. Add data/ directory or .graph-browser.json to your repo"
+            )
 
 tryFetchManifest
   :: Maybe String
@@ -203,28 +209,29 @@ tryFetchUrl mToken url = do
 
 stripPrefix :: String -> String -> Maybe String
 stripPrefix prefix str =
-  if String.take (String.length prefix) str == prefix
-    then Just (String.drop (String.length prefix) str)
-    else Nothing
+  if String.take (String.length prefix) str == prefix then Just (String.drop (String.length prefix) str)
+  else Nothing
 
 stripSuffix :: String -> String -> String
 stripSuffix suffix str =
-  let sLen = String.length suffix
-      strLen = String.length str
+  let
+    sLen = String.length suffix
+    strLen = String.length str
   in
-    if strLen >= sLen
-      && String.drop (strLen - sLen) str == suffix
-      then String.take (strLen - sLen) str
-      else str
+    if
+      strLen >= sLen
+        && String.drop (strLen - sLen) str == suffix then String.take (strLen - sLen) str
+    else str
 
 stripTrailingSlash :: String -> String
 stripTrailingSlash str =
-  let len = String.length str
+  let
+    len = String.length str
   in
-    if len > 0
-      && String.drop (len - 1) str == "/"
-      then String.take (len - 1) str
-      else str
+    if
+      len > 0
+        && String.drop (len - 1) str == "/" then String.take (len - 1) str
+    else str
 
 takeUntil :: String -> String -> String
 takeUntil sep str =
@@ -241,6 +248,7 @@ splitFirst sep str =
     Just idx -> Just
       { before: String.take idx str
       , after: String.drop
-          (idx + String.length sep) str
+          (idx + String.length sep)
+          str
       }
     Nothing -> Nothing

--- a/src/RepoManager.purs
+++ b/src/RepoManager.purs
@@ -115,8 +115,8 @@ renderRepoItem activeId entry =
   HH.div
     [ cls
         ( "repo-item"
-            <> if activeId == Just entry.id
-              then " active"
+            <>
+              if activeId == Just entry.id then " active"
               else ""
         )
     , HE.onClick \_ -> Select entry

--- a/src/Viewer.purs
+++ b/src/Viewer.purs
@@ -19,7 +19,7 @@ import Effect.Class (liftEffect)
 import FFI.Cytoscape as Cy
 import Fetch (Method(..), fetch)
 import Graph.Cytoscape as GCy
-import Graph.Operations (neighborhood, subgraph)
+import Graph.Operations (filterBySources, neighborhood, subgraph)
 import Foreign (Foreign, unsafeToForeign)
 import Foreign.Object as FO
 import Graph.Search (SearchResult(..), search)
@@ -64,6 +64,7 @@ import Viewer.Controls (renderControls, renderLegend, renderGraphContext)
 import Viewer.Tutorial (currentStop)
 import Viewer.QueryPanel (renderQueryPanel)
 import Viewer.Sidebar (renderSidebar)
+import Viewer.SourcesPanel (renderSourcesPanel)
 import Viewer.Loader
   ( loadConfig
   , loadGraphData
@@ -118,6 +119,8 @@ viewer = H.mkComponent
       , paramOptions: Map.empty
       , loadedTutorials: []
       , panelTab: QueriesTab
+      , hiddenSources: Set.empty
+      , showSourcesPanel: false
       }
   , render
   , eval: H.mkEval H.defaultEval
@@ -130,7 +133,12 @@ render :: forall m. State -> H.ComponentHTML Action () m
 render state =
   HH.div [ cls "app" ]
     ( ( if Array.null state.queryCatalog then []
-        else [ renderQueryPanel state ]
+        else
+          [ HH.div [ cls "left-column" ]
+              [ renderSourcesPanel state
+              , renderQueryPanel state
+              ]
+          ]
       )
         <>
           [ HH.div [ cls "graph-container" ]
@@ -763,6 +771,20 @@ handleAction = case _ of
       , promptCopied = false
       }
 
+  ToggleSource iri -> do
+    state <- H.get
+    let
+      nextHidden =
+        if Set.member iri state.hiddenSources then
+          Set.delete iri state.hiddenSources
+        else
+          Set.insert iri state.hiddenSources
+    H.modify_ _ { hiddenSources = nextHidden }
+    renderGraph
+
+  ToggleSourcesPanel ->
+    H.modify_ \s -> s { showSourcesPanel = not s.showSourcesPanel }
+
   SetParamValue name value -> do
     state <- H.get
     let values = Map.insert name value state.paramValues
@@ -836,7 +858,7 @@ renderGraph
 renderGraph = do
   state <- H.get
   let
-    visible = case state.selected of
+    base = case state.selected of
       Just node ->
         let
           hood = neighborhood state.depth
@@ -845,6 +867,7 @@ renderGraph = do
         in
           subgraph hood state.graph
       Nothing -> state.graph
+    visible = filterBySources state.hiddenSources base
 
   liftEffect $ Cy.setFocusElements
     (GCy.toElements visible)

--- a/src/Viewer.purs
+++ b/src/Viewer.purs
@@ -611,6 +611,7 @@ handleAction = case _ of
                 , label: edge.label
                 , description: edge.description
                 , predicateRef: edge.predicateRef
+                , sources: []
                 }
             in
               case srcNode, tgtNode of
@@ -632,6 +633,7 @@ handleAction = case _ of
                     , description: ""
                     , links: []
                     , ontologyRef: Nothing
+                    , sources: []
                     }
                     { id: edge.targetId
                     , label: edge.targetLabel
@@ -640,6 +642,7 @@ handleAction = case _ of
                     , description: ""
                     , links: []
                     , ontologyRef: Nothing
+                    , sources: []
                     }
                     state.promptInput
           Nothing -> ""

--- a/src/Viewer/Loader.purs
+++ b/src/Viewer/Loader.purs
@@ -41,11 +41,22 @@ resolveUrl base path =
   if String.take 4 path == "http" then path
   else base <> path
 
+-- | URN prefix for per-source named graphs. The full source IRI is
+-- | `urn:gb:source:` followed by the source path as configured.
+sourceIriPrefix :: String
+sourceIriPrefix = "urn:gb:source:"
+
+-- | Build the source IRI for a configured graphSource path.
+-- | Empty path yields empty — a signal to load into the default graph.
+sourceIriForPath :: String -> String
+sourceIriForPath "" = ""
+sourceIriForPath path = sourceIriPrefix <> path
+
 graphSourceLocations
   :: forall r
    . { baseUrl :: String, graphUrl :: String | r }
   -> Config
-  -> Array { format :: String, url :: String }
+  -> Array { format :: String, url :: String, sourceIri :: String }
 graphSourceLocations urls cfg =
   case cfg.graphSources of
     sources | not (Array.null sources) ->
@@ -53,6 +64,7 @@ graphSourceLocations urls cfg =
         ( \source ->
             { format: source.format
             , url: resolveUrl urls.baseUrl source.path
+            , sourceIri: sourceIriForPath source.path
             }
         )
         sources
@@ -61,11 +73,13 @@ graphSourceLocations urls cfg =
         Just source ->
           [ { format: source.format
             , url: resolveUrl urls.baseUrl source.path
+            , sourceIri: sourceIriForPath source.path
             }
           ]
         Nothing ->
           [ { format: "application/json"
             , url: urls.graphUrl
+            , sourceIri: ""
             }
           ]
 
@@ -87,7 +101,7 @@ loadConfig url = do
     Right json -> decodeConfig json
 
 loadGraphData
-  :: Array { format :: String, url :: String }
+  :: Array { format :: String, url :: String, sourceIri :: String }
   -> Aff (Either String { graph :: Graph, ontologyKinds :: Map.Map KindId KindDef })
 loadGraphData locations =
   case Array.uncons locations of
@@ -118,16 +132,24 @@ loadGraphData locations =
         Right result -> result
 
 fetchAndParseRdf
-  :: { format :: String, url :: String }
+  :: { format :: String, url :: String, sourceIri :: String }
   -> Aff (Array Oxigraph.ImportedRdfQuad)
 fetchAndParseRdf location = do
   resp <- fetch location.url { method: GET }
   body <- resp.text
   absUrl <- liftEffect (absoluteUrl location.url)
-  liftEffect $ Oxigraph.parseQuads location.format absUrl body
+  quads <- liftEffect $ Oxigraph.parseQuads location.format absUrl body
+  -- Parsed quads come in with an empty `graph` field (they were read out
+  -- of a flat Turtle source). Stamp the configured source IRI so the
+  -- import pipeline can track which source each quad came from.
+  pure (map (tagSource location.sourceIri) quads)
+  where
+  tagSource :: String -> Oxigraph.ImportedRdfQuad -> Oxigraph.ImportedRdfQuad
+  tagSource "" q = q
+  tagSource iri q = q { graph = iri }
 
 loadSparqlStore
-  :: Array { format :: String, url :: String }
+  :: Array { format :: String, url :: String, sourceIri :: String }
   -> Aff (Either String Oxigraph.OxigraphStore)
 loadSparqlStore locations = do
   parsed <- try do
@@ -136,7 +158,9 @@ loadSparqlStore locations = do
       resp <- fetch location.url { method: GET }
       body <- resp.text
       absUrl <- liftEffect (absoluteUrl location.url)
-      liftEffect $ Oxigraph.loadRdf store location.format absUrl "" body
+      liftEffect $ Oxigraph.loadRdf store location.format absUrl
+        location.sourceIri
+        body
     pure store
   pure case parsed of
     Left err -> Left (show err)

--- a/src/Viewer/Loader.purs
+++ b/src/Viewer/Loader.purs
@@ -136,7 +136,7 @@ loadSparqlStore locations = do
       resp <- fetch location.url { method: GET }
       body <- resp.text
       absUrl <- liftEffect (absoluteUrl location.url)
-      liftEffect $ Oxigraph.loadRdf store location.format absUrl body
+      liftEffect $ Oxigraph.loadRdf store location.format absUrl "" body
     pure store
   pure case parsed of
     Left err -> Left (show err)

--- a/src/Viewer/SourcesPanel.purs
+++ b/src/Viewer/SourcesPanel.purs
@@ -1,0 +1,112 @@
+module Viewer.SourcesPanel where
+
+import Prelude
+
+import Data.Array as Array
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Set as Set
+import Data.String as String
+import Graph.Types (Config, GraphSource)
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+import Viewer.Helpers (cls)
+import Viewer.Types (Action(..), State)
+
+-- | URN prefix used for per-source named graphs (mirror of
+-- | `Viewer.Loader.sourceIriPrefix`). Kept as a local constant so this
+-- | module does not depend on Loader.
+sourceIriPrefix :: String
+sourceIriPrefix = "urn:gb:source:"
+
+-- | Build the source IRI for a configured graphSource path.
+sourceIriForPath :: String -> String
+sourceIriForPath "" = ""
+sourceIriForPath path = sourceIriPrefix <> path
+
+-- | Render a collapsible "Sources" panel listing every configured
+-- | graphSource with a checkbox. Hiding a source removes any
+-- | node/edge whose `sources` is a non-empty subset of hidden sources;
+-- | nodes/edges with empty sources remain visible.
+renderSourcesPanel
+  :: forall m. State -> H.ComponentHTML Action () m
+renderSourcesPanel state =
+  let
+    sources = configuredSources state.config
+  in
+    if Array.null sources then HH.text ""
+    else
+      HH.div [ cls "sources-panel" ]
+        [ HH.div
+            [ cls "sources-header"
+            , HE.onClick \_ -> ToggleSourcesPanel
+            ]
+            [ HH.span [ cls "sources-title" ]
+                [ HH.text "Sources" ]
+            , HH.span [ cls "sources-count" ]
+                [ HH.text (show (Array.length sources)) ]
+            , HH.span [ cls "sources-chevron" ]
+                [ HH.text
+                    if state.showSourcesPanel then "▾" else "▸"
+                ]
+            ]
+        , if state.showSourcesPanel then
+            HH.div [ cls "sources-list" ]
+              (map (renderRow state) sources)
+          else HH.text ""
+        ]
+
+renderRow
+  :: forall m
+   . State
+  -> GraphSource
+  -> H.ComponentHTML Action () m
+renderRow state source =
+  let
+    iri = sourceIriForPath source.path
+    hidden = Set.member iri state.hiddenSources
+    display =
+      if source.label /= "" then source.label
+      else sourceDisplayName source.path
+  in
+    HH.label [ cls "sources-row" ]
+      [ HH.input
+          [ HP.type_ HP.InputCheckbox
+          , HP.checked (not hidden)
+          , HE.onChange \_ -> ToggleSource iri
+          ]
+      , HH.span [ cls "sources-row-label" ]
+          [ HH.text display ]
+      ]
+
+-- | Configured sources across both 'graphSources' and the legacy
+-- | 'graphSource' singleton. Entries with an empty path are skipped so
+-- | the panel never lists the default-graph placeholder.
+configuredSources :: Config -> Array GraphSource
+configuredSources cfg =
+  Array.filter (\s -> s.path /= "")
+    ( cfg.graphSources
+        <> case cfg.graphSource of
+          Nothing -> []
+          Just s -> [ s ]
+    )
+
+-- | Last path segment, with common RDF suffixes dropped. Fallback
+-- | display when no 'label' is configured on the source.
+sourceDisplayName :: String -> String
+sourceDisplayName path =
+  let
+    segs = String.split (String.Pattern "/") path
+    last = fromMaybe path (Array.last segs)
+  in
+    dropExt last suffixes
+
+dropExt :: String -> Array String -> String
+dropExt s suffixes =
+  case Array.head (Array.mapMaybe (\ext -> String.stripSuffix (String.Pattern ext) s) suffixes) of
+    Just stripped -> stripped
+    Nothing -> s
+
+suffixes :: Array String
+suffixes = [ ".ttl", ".nq", ".nt", ".trig", ".rdf", ".jsonld" ]

--- a/src/Viewer/Types.purs
+++ b/src/Viewer/Types.purs
@@ -2,6 +2,7 @@ module Viewer.Types where
 
 import Data.Map as Map
 import Data.Maybe (Maybe)
+import Data.Set (Set)
 import Graph.Types (Config, Node, Graph)
 import Graph.Query as Query
 import Graph.Views as Views
@@ -78,6 +79,11 @@ type State =
   , paramOptions :: Map.Map String (Array String)
   , loadedTutorials :: Array Tutorial
   , panelTab :: PanelTab
+  -- | IRIs of source graphs the user has hidden. Nodes/edges whose
+  -- | sources is a non-empty subset of this set are filtered from the
+  -- | view. Nodes/edges with empty sources are always visible.
+  , hiddenSources :: Set String
+  , showSourcesPanel :: Boolean
   }
 
 -- | Actions the component can handle.
@@ -112,6 +118,8 @@ data Action
   | ToggleQueryCatalog
   | SetParamValue String String
   | SetPanelTab PanelTab
+  | ToggleSource String
+  | ToggleSourcesPanel
 
 data PanelTab = QueriesTab | ToursTab
 

--- a/src/Vocab/Publish/Main.purs
+++ b/src/Vocab/Publish/Main.purs
@@ -200,22 +200,25 @@ namespaceTitle namespace =
 
 namespaceRelativePath :: String -> String -> String
 namespaceRelativePath siteBasePath namespace =
-  let path = namespacePath namespace
-      trimmedBase = normalizedBasePath siteBasePath
-      withoutBase =
-        if trimmedBase /= "" && String.take (String.length trimmedBase) path == trimmedBase then
-          String.drop (String.length trimmedBase) path
-        else
-          path
-      parts = Array.filter (_ /= "") (split (Pattern "/") withoutBase)
-  in joinWith "/" parts
+  let
+    path = namespacePath namespace
+    trimmedBase = normalizedBasePath siteBasePath
+    withoutBase =
+      if trimmedBase /= "" && String.take (String.length trimmedBase) path == trimmedBase then
+        String.drop (String.length trimmedBase) path
+      else
+        path
+    parts = Array.filter (_ /= "") (split (Pattern "/") withoutBase)
+  in
+    joinWith "/" parts
 
 namespaceKey :: String -> String -> Maybe String
 namespaceKey siteBasePath iri = do
   idx <- String.lastIndexOf (Pattern "#") iri
-  let namespace = String.take (idx + 1) iri
-      path = namespacePath namespace
-      base = normalizedBasePath siteBasePath
+  let
+    namespace = String.take (idx + 1) iri
+    path = namespacePath namespace
+    base = normalizedBasePath siteBasePath
   if isHttpNamespace namespace && isVocabPath base path then
     Just namespace
   else
@@ -260,17 +263,21 @@ isVocabPath :: String -> String -> Boolean
 isVocabPath base path
   | base == "" = String.take 7 path == "/vocab/"
   | otherwise =
-      let prefix = base <> "/vocab/"
-      in String.take (String.length prefix) path == prefix
+      let
+        prefix = base <> "/vocab/"
+      in
+        String.take (String.length prefix) path == prefix
 
 namespaceTail :: String -> String
 namespaceTail namespace =
-  let withoutHash =
-        case String.lastIndexOf (Pattern "#") namespace of
-          Just idx -> String.take idx namespace
-          Nothing -> namespace
-      pieces = Array.filter (_ /= "") (split (Pattern "/") withoutHash)
-  in fromMaybe namespace (Array.last pieces)
+  let
+    withoutHash =
+      case String.lastIndexOf (Pattern "#") namespace of
+        Just idx -> String.take idx namespace
+        Nothing -> namespace
+    pieces = Array.filter (_ /= "") (split (Pattern "/") withoutHash)
+  in
+    fromMaybe namespace (Array.last pieces)
 
 fallbackLabel :: String -> String
 fallbackLabel fragment = decodeOrOriginal fragment
@@ -281,8 +288,10 @@ decodeOrOriginal value =
 
 hushDecode :: String -> Maybe String
 hushDecode value =
-  let decoded = decodeUriComponent value
-  in Just decoded
+  let
+    decoded = decodeUriComponent value
+  in
+    Just decoded
 
 literalValue :: Array ImportedRdfQuad -> String -> String -> Maybe String
 literalValue quads subject predicate =
@@ -370,8 +379,10 @@ renderSourceArtifacts sourcePaths =
   joinWith ", "
     ( map
         ( \path ->
-            let href = publishedArtifactHref path
-            in "<a href=\"" <> escapeHtml href <> "\">" <> escapeHtml href <> "</a>"
+            let
+              href = publishedArtifactHref path
+            in
+              "<a href=\"" <> escapeHtml href <> "\">" <> escapeHtml href <> "</a>"
         )
         sourcePaths
     )

--- a/test/Test/ConfigDecode.purs
+++ b/test/Test/ConfigDecode.purs
@@ -31,9 +31,9 @@ spec = describe "Graph.Decode.decodeConfig" do
       Left err -> fail err
       Right config -> do
         config.graphSource `shouldEqual`
-          Just { format: "text/turtle", path: "data/rdf/graph.ttl" }
+          Just { format: "text/turtle", path: "data/rdf/graph.ttl", label: "" }
         config.graphSources `shouldEqual`
-          [ { format: "text/turtle", path: "data/rdf/graph.ttl" } ]
+          [ { format: "text/turtle", path: "data/rdf/graph.ttl", label: "" } ]
 
   it "decodes ordered graphSources for merged RDF datasets" do
     let

--- a/test/Test/OntologyImport.purs
+++ b/test/Test/OntologyImport.purs
@@ -51,7 +51,7 @@ spec = describe "Ontology import" do
     quads <- liftEffect $ Oxigraph.parseQuads "text/turtle" fixtureBase turtle
     store <- liftEffect do
       s <- Oxigraph.createStore
-      Oxigraph.loadRdf s "text/turtle" fixtureBase turtle
+      Oxigraph.loadRdf s "text/turtle" fixtureBase "" turtle
       pure s
     catalogBody <- liftEffect $ readTextFile UTF8 "data/queries.json"
     case jsonParser catalogBody >>= decodeQueryCatalog, Rdf.Import.importGraph quads of

--- a/test/Test/SelfGraph.purs
+++ b/test/Test/SelfGraph.purs
@@ -27,7 +27,7 @@ loadStore
 loadStore baseIri path = liftEffect do
   turtle <- readTextFile UTF8 path
   s <- Oxigraph.createStore
-  Oxigraph.loadRdf s "text/turtle" baseIri turtle
+  Oxigraph.loadRdf s "text/turtle" baseIri "" turtle
   pure s
 
 graphBase :: String

--- a/test/Test/Sparql.purs
+++ b/test/Test/Sparql.purs
@@ -41,7 +41,7 @@ spec = describe "SPARQL store" do
   it "creates a store and loads turtle" do
     store <- liftEffect do
       s <- Oxigraph.createStore
-      Oxigraph.loadRdf s "text/turtle" baseIri sampleTurtle
+      Oxigraph.loadRdf s "text/turtle" baseIri "" sampleTurtle
       pure s
     -- If we get here without exception, loading succeeded
     pure unit
@@ -49,7 +49,7 @@ spec = describe "SPARQL store" do
   it "queries all nodes" do
     store <- liftEffect do
       s <- Oxigraph.createStore
-      Oxigraph.loadRdf s "text/turtle" baseIri sampleTurtle
+      Oxigraph.loadRdf s "text/turtle" baseIri "" sampleTurtle
       pure s
     ids <- liftEffect $ Oxigraph.querySparqlNodeIds store
       "SELECT ?node WHERE { ?node a ?type }"
@@ -60,7 +60,7 @@ spec = describe "SPARQL store" do
   it "queries nodes by kind" do
     store <- liftEffect do
       s <- Oxigraph.createStore
-      Oxigraph.loadRdf s "text/turtle" baseIri sampleTurtle
+      Oxigraph.loadRdf s "text/turtle" baseIri "" sampleTurtle
       pure s
     ids <- liftEffect $ Oxigraph.querySparqlNodeIds store
       "PREFIX gbk: <https://example.org/kinds#>\nSELECT ?node WHERE { ?node a gbk:module }"
@@ -70,7 +70,7 @@ spec = describe "SPARQL store" do
   it "returns empty for no matches" do
     store <- liftEffect do
       s <- Oxigraph.createStore
-      Oxigraph.loadRdf s "text/turtle" baseIri sampleTurtle
+      Oxigraph.loadRdf s "text/turtle" baseIri "" sampleTurtle
       pure s
     ids <- liftEffect $ Oxigraph.querySparqlNodeIds store
       "PREFIX gbk: <https://example.org/kinds#>\nSELECT ?node WHERE { ?node a gbk:nonexistent }"
@@ -79,7 +79,7 @@ spec = describe "SPARQL store" do
   it "querySparql returns binding records" do
     store <- liftEffect do
       s <- Oxigraph.createStore
-      Oxigraph.loadRdf s "text/turtle" baseIri sampleTurtle
+      Oxigraph.loadRdf s "text/turtle" baseIri "" sampleTurtle
       pure s
     rows <- liftEffect $ Oxigraph.querySparql store
       "PREFIX gbk: <https://example.org/kinds#>\nSELECT ?node WHERE { ?node a gbk:ffi }"


### PR DESCRIPTION
Closes #70. Closes #74.

Implements **A2** — per-source named graphs at the RDF layer, with SPARQL queries unioning all named graphs back into the default graph so existing views continue to work unchanged. Adds a collapsible Sources panel for interactive per-source visibility.

## Commits

0. \`style: apply purs-tidy formatting to pre-existing files\` — fix the lint gate for four files that predate the CI lint step.
1. \`feat(ffi): carry named graph value on ImportedRdfQuad\` — parseQuads returns \`quad.graph.value\`.
2. \`feat(ffi): loadRdf accepts an optional target named graph\` — \`toGraphName\` argument.
3. \`feat(ffi): query SPARQL with use_default_graph_as_union\` — existing queries keep matching across named graphs.
4. \`feat(loader): stamp each source with a named-graph IRI\` — \`urn:gb:source:<path>\` threaded through both load paths.
5. \`feat(graph): Node and Edge carry source graph IRIs\` — \`sources :: Array String\` populated from quad provenance.
6. \`feat(config): graphSources entries accept an optional label\` — schema + decoder.
7. \`feat(ui): Sources sidebar panel with per-source visibility toggle\` — collapsible panel with checkboxes; hides elements whose sources are fully hidden; edges to hidden nodes are dropped.

## Verification

- \`just ci\` green (lint + build + validate).
- \`just test\` — 26/26 pass.
- Downstream smoke-test against \`lambdasistemi/cardano-knowledge-maps\` (5 sources, 3689 triples, 30 SPARQL views):
  - Store exposes 5 named graphs, one per source.
  - \`GRAPH ?g { ?s ?p ?o }\` and \`{ ?s ?p ?o }\` with union both return 3689 — identical.
  - All existing SPARQL views render unchanged (\"Budget 2026 Proposals\" returns the expected 17 nodes).
  - Sources panel lists 5 rows. Hiding \`indigo-v2030rs.ttl\` drops 8 nodes (including all Indigo-exclusive concepts) and 2 proposals remain visible. Re-enabling restores 132/3.

## Not in this PR (follow-up)

- Persistence of hidden-source state via \`Persist.purs\`.
- Tooltip / Detail pane showing the source list on hover / selection.
- CSS styling for the Sources panel (currently inherits generic \`.app\` spacing — functional but unstyled).

## Test plan

- [ ] CI green
- [ ] Downstream preview (kmaps): Sources panel appears, toggles work, existing queries unchanged