### PR TITLE
feat!: versioned lib + schemas distribution; build/validate-action require pinned version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
@@ -11,8 +15,39 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: node
+
+  publish-bundle:
+    needs: release
+    if: needs.release.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag_name }}
+      - uses: paolino/dev-assets/setup-nix@v0.0.1
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      # Build the lib bundle pinned to the release tag and upload it to
+      # the GitHub release as 'lib-bundle.tar.gz'. Data repositories
+      # consume this asset via build-action's required `version:` input,
+      # so every published release is permanently downloadable.
+      - run: |
+          nix develop --quiet -c just install
+          nix develop --quiet -c just bundle-lib
+          tar -czf lib-bundle.tar.gz -C dist index.html index.js
+          tar -czf schemas.tar.gz -C schema .
+      - run: |
+          gh release upload "${{ needs.release.outputs.tag_name }}" \
+            lib-bundle.tar.gz schemas.tar.gz --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -189,8 +189,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: lambdasistemi/graph-browser/validate-action@main
-      - uses: lambdasistemi/graph-browser/build-action@main
+      - uses: lambdasistemi/graph-browser/validate-action@v0.4.1
+        with:
+          version: v0.4.1
+      - uses: lambdasistemi/graph-browser/build-action@v0.4.1
+        with:
+          version: v0.4.1
       - uses: actions/upload-pages-artifact@v4
         with:
           path: site
@@ -198,7 +202,9 @@ jobs:
         uses: actions/deploy-pages@v5
 ```
 
-No build tools needed — the actions download the app and assemble the site.
+No build tools needed — the actions download the pinned `lib-bundle.tar.gz` and `schemas.tar.gz` from the release and assemble the site.
+
+> **Pin both the action ref and the `version:` input to the same release tag.** Replace `v0.4.1` with whatever release you want; check [Releases](https://github.com/lambdasistemi/graph-browser/releases) for the latest. Upstream changes to graph-browser only reach your deployed site when you bump these pins.
 
 ### Option 2: Use the hosted universal viewer
 
@@ -307,13 +313,15 @@ Validate your data against the schemas in [`schema/`](schema/):
 
 ### CI Validation for Data Repos
 
-Graph-browser publishes a reusable GitHub Action that validates your data against all schemas, checks edge integrity, kind references, duplicate IDs, and tutorial node references. Add it as a step in your workflow:
+Graph-browser publishes a reusable GitHub Action that validates your data against all schemas, checks edge integrity, kind references, duplicate IDs, and tutorial node references. Pin both the action ref and the `version:` input to the same release tag:
 
 ```yaml
-- uses: lambdasistemi/graph-browser/validate-action@main
+- uses: lambdasistemi/graph-browser/validate-action@v0.4.1
   with:
+    version: v0.4.1         # required — picks the schemas.tar.gz from this release
     data-dir: data          # optional, default: data
-    schema-ref: main        # optional, pin to tag/sha
+    # Or, for hermetic builds, point at a local schema directory and skip the download:
+    # schema-dir: schema
 ```
 
 ## Generating Data with an LLM

--- a/build-action/README.md
+++ b/build-action/README.md
@@ -1,0 +1,41 @@
+# build-action
+
+Assemble a deployable graph-browser site from a `data/` directory by downloading a pinned release bundle.
+
+## Usage
+
+```yaml
+- uses: lambdasistemi/graph-browser/build-action@v0.4.1
+  with:
+    version: v0.4.1   # REQUIRED — pin both the action ref and the version
+    data-dir: data    # default: data
+    output-dir: site  # default: site
+```
+
+| Input | Required | Description |
+|---|---|---|
+| `version` | yes | graph-browser release tag whose `lib-bundle.tar.gz` to install (e.g. `v0.4.1`). |
+| `data-dir` | no, default `data` | Path to the data directory in your repository. |
+| `output-dir` | no, default `site` | Path to write the assembled site. |
+
+## What it does
+
+1. Downloads `lib-bundle.tar.gz` from `github.com/lambdasistemi/graph-browser/releases/download/<version>/` and extracts `index.html` + `index.js` into `output-dir`.
+2. Copies `data-dir` into `output-dir/data`.
+3. Generates `output-dir/data/views/index.json` if `data/views/` exists and the index is missing.
+
+The output is ready to upload to GitHub Pages or any static host.
+
+## Why pin
+
+The bundle is your runtime. Pinning the `version:` input (and the action ref) means your deployed site never changes unless you bump the pin — graph-browser PRs and Pages republishes can never silently break or alter your data repo's UI.
+
+## Migration from `@main`
+
+If you previously used:
+
+```yaml
+- uses: lambdasistemi/graph-browser/build-action@main
+```
+
+…replace it with the pinned form above. Pick a release from <https://github.com/lambdasistemi/graph-browser/releases>.

--- a/build-action/action.yml
+++ b/build-action/action.yml
@@ -1,7 +1,14 @@
 name: 'Build Graph Browser Site'
-description: 'Assemble a deployable graph-browser site from a data/ directory — no build tools required'
+description: 'Assemble a deployable graph-browser site from a data/ directory — pinned to a graph-browser release'
 
 inputs:
+  version:
+    description: |
+      graph-browser release tag to install (for example "v0.4.1"). REQUIRED —
+      pin explicitly so upstream changes never reach your deployed site
+      without you opting in. Each release uploads a 'lib-bundle.tar.gz'
+      asset that this action downloads and unpacks.
+    required: true
   data-dir:
     description: 'Path to the data directory'
     required: false
@@ -14,14 +21,20 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Download graph-browser app
+    - name: Download pinned graph-browser lib bundle
       shell: bash
       run: |
         OUT="${{ inputs.output-dir }}"
-        BASE="https://lambdasistemi.github.io/graph-browser/lib"
+        VERSION="${{ inputs.version }}"
+        if [ -z "$VERSION" ]; then
+          echo "::error::build-action requires a 'version:' input (e.g. v0.4.1)." >&2
+          echo "See https://github.com/lambdasistemi/graph-browser/releases for available versions." >&2
+          exit 1
+        fi
+        URL="https://github.com/lambdasistemi/graph-browser/releases/download/${VERSION}/lib-bundle.tar.gz"
         mkdir -p "$OUT"
-        curl -sfL "$BASE/index.html" -o "$OUT/index.html"
-        curl -sfL "$BASE/index.js" -o "$OUT/index.js"
+        echo "Fetching $URL"
+        curl -sfL "$URL" | tar -xz -C "$OUT"
 
     - name: Copy data
       shell: bash

--- a/validate-action/README.md
+++ b/validate-action/README.md
@@ -1,0 +1,51 @@
+# validate-action
+
+Validate a graph-browser data repository against a pinned release of the graph-browser schemas.
+
+## Usage
+
+```yaml
+- uses: lambdasistemi/graph-browser/validate-action@v0.4.1
+  with:
+    version: v0.4.1   # required unless schema-dir is set
+    data-dir: data    # default: data
+    rdf-dir: data/rdf # default: data/rdf
+```
+
+For hermetic builds, point at a local schemas directory instead:
+
+```yaml
+- uses: lambdasistemi/graph-browser/validate-action@v0.4.1
+  with:
+    schema-dir: schema
+```
+
+| Input | Required | Description |
+|---|---|---|
+| `version` | yes (unless `schema-dir`) | Release tag whose `schemas.tar.gz` to download. |
+| `schema-dir` | yes (unless `version`) | Local path to schemas; skips download. |
+| `data-dir` | no, default `data` | Path to the data directory in your repository. |
+| `rdf-dir` | no, default `data/rdf` | Path to the RDF directory for SHACL validation. |
+
+## What it does
+
+1. Resolves schemas — either from the pinned release (`schemas.tar.gz`) or a local directory.
+2. JSON-Schema-validates `data/config.json`, `data/graph.json` (if present), `data/tutorials/*.json`, and `data/views/*.json` with `ajv`.
+3. Checks referential integrity: every edge endpoint exists, every kind is declared, no duplicate node IDs, every tutorial stop references a valid node.
+4. If RDF files are present, runs Apache Jena SHACL against the bundled shapes.
+
+## Why pin
+
+Pinning the schema version means your data conforms to a known revision. New schema rules upstream don't fail your CI until you opt in by bumping the pin.
+
+## Migration from `schema-ref: main`
+
+If you previously used:
+
+```yaml
+- uses: lambdasistemi/graph-browser/validate-action@main
+  with:
+    schema-ref: main
+```
+
+…replace it with the pinned form above. The deprecated `schema-ref` input has been removed.

--- a/validate-action/action.yml
+++ b/validate-action/action.yml
@@ -2,6 +2,15 @@ name: 'Validate Graph Browser Data'
 description: 'Validate graph-browser data/ directory against schemas and referential integrity'
 
 inputs:
+  version:
+    description: |
+      graph-browser release tag whose schemas to validate against
+      (for example "v0.4.1"). REQUIRED unless 'schema-dir' is given.
+      The schemas are downloaded from the release's 'schemas.tar.gz'
+      asset, so each data repository pins exactly which schema version
+      it conforms to.
+    required: false
+    default: ''
   data-dir:
     description: 'Path to the data directory'
     required: false
@@ -10,12 +19,8 @@ inputs:
     description: 'Path to the RDF directory for optional SHACL validation'
     required: false
     default: 'data/rdf'
-  schema-ref:
-    description: 'Git ref to fetch schemas from (tag, branch, or SHA)'
-    required: false
-    default: 'main'
   schema-dir:
-    description: 'Local path to schemas (skips fetching from GitHub)'
+    description: 'Local path to schemas (overrides version: when set)'
     required: false
     default: ''
 
@@ -33,12 +38,16 @@ runs:
       run: |
         if [ -n "${{ inputs.schema-dir }}" ]; then
           echo "SCHEMA_DIR=${{ inputs.schema-dir }}" >> "$GITHUB_ENV"
-        else
+        elif [ -n "${{ inputs.version }}" ]; then
           SCHEMA_DIR=$(mktemp -d)
           echo "SCHEMA_DIR=$SCHEMA_DIR" >> "$GITHUB_ENV"
-          for f in config.schema.json graph.schema.json tutorial-index.schema.json tutorial.schema.json view.schema.json; do
-            curl -sfL "https://raw.githubusercontent.com/lambdasistemi/graph-browser/${{ inputs.schema-ref }}/schema/$f" -o "$SCHEMA_DIR/$f"
-          done
+          URL="https://github.com/lambdasistemi/graph-browser/releases/download/${{ inputs.version }}/schemas.tar.gz"
+          echo "Fetching $URL"
+          curl -sfL "$URL" | tar -xz -C "$SCHEMA_DIR"
+        else
+          echo "::error::validate-action requires either 'version:' (e.g. v0.4.1) or 'schema-dir:'." >&2
+          echo "See https://github.com/lambdasistemi/graph-browser/releases for available versions." >&2
+          exit 1
         fi
 
     - name: Install validator


### PR DESCRIPTION
## Why

Today \`lambdasistemi/graph-browser/build-action@main\` curls the runtime bundle from \`lambdasistemi.github.io/graph-browser/lib/index.{html,js}\` — a moving artifact. Any push to \`main\` republishes Pages, which means every downstream data repository's *next* CI run silently picks up the new bundle, with no version control or opt-in. \`validate-action\` has the same drift through its \`schema-ref: main\` default. That's the opposite of the reproducibility the rest of the toolchain (Nix flake, flake.lock pin in data repos) provides.

This PR fixes the architectural defect by giving every release a pinnable bundle and making the actions require an explicit version.

## Commits

1. \`feat(release): publish lib-bundle.tar.gz + schemas.tar.gz per release\` — release-please tags trigger a publish-bundle job that builds the lib via Nix and uploads two assets to the release.
2. \`feat(build-action): require pinned 'version:' input\` — downloads from \`releases/download/<version>/lib-bundle.tar.gz\`. Missing version exits with a helpful error.
3. \`feat(validate-action): pin schemas to a release version\` — same shape, downloads \`schemas.tar.gz\`. \`schema-ref\` removed; \`schema-dir\` retained as the hermetic-build escape hatch.
4. \`docs: explain version pinning for build-action and validate-action\` — README updates plus per-action READMEs covering inputs, rationale, and migration from \`@main\`.

## BREAKING CHANGES

Any data repository using \`build-action@main\` or \`validate-action@main\` *without* the new \`version:\` input will fail on its next CI run, with an error message linking to the releases page. Migration is a two-line change per workflow: bump the action ref to a release tag and pass \`version: <same tag>\`.

## Bootstrap

Once this lands, the next release-please release will be the first to ship \`lib-bundle.tar.gz\` and \`schemas.tar.gz\`. Existing data repositories should pin to that release.

## Test plan

- [ ] CI green
- [ ] On release-please tag: \`publish-bundle\` job uploads both assets
- [ ] Data-repo dry-run with \`version: <tag>\` builds and validates as before