### PR TITLE
fix: add a visible theme toggle to the viewer

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -6,8 +6,15 @@
 <title>Graph Browser</title>
 <script>
   (function () {
+    function loadStoredTheme() {
+      try {
+        return window.localStorage ? window.localStorage.getItem('graph-browser:theme') : null;
+      } catch (_) {
+        return null;
+      }
+    }
     var params = new URLSearchParams(window.location.search);
-    var requested = (params.get('theme') || 'auto').toLowerCase();
+    var requested = (params.get('theme') || loadStoredTheme() || 'auto').toLowerCase();
     if (requested !== 'light' && requested !== 'dark' && requested !== 'auto') {
       requested = 'auto';
     }
@@ -189,6 +196,15 @@
 
   .control-btn:hover { background: var(--border); border-color: var(--text-muted); }
   .control-btn.active { background: var(--accent-bg); border-color: var(--accent); color: var(--accent); }
+  .theme-toggle-btn {
+    min-width: 36px;
+    padding: 6px 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    line-height: 1;
+  }
 
   .search-container {
     position: absolute;

--- a/specs/012-expand-collapse/checklists/requirements.md
+++ b/specs/012-expand-collapse/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Expand and Collapse Nodes
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- View portability (export, import, tours) is intentionally out of scope and covered by a sibling spec.
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.

--- a/specs/012-expand-collapse/spec.md
+++ b/specs/012-expand-collapse/spec.md
@@ -1,0 +1,116 @@
+# Feature Specification: Expand and Collapse Nodes
+
+**Feature Branch**: `012-expand-collapse`
+**Created**: 2026-04-23
+**Status**: Draft
+**Input**: User description: "When browsing a large graph (e.g. Cardano Knowledge Maps), users want to shape the graph by clicking a node to expand its neighborhood or collapse it, so they can progressively grow a focused subset instead of being shown everything at once."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Grow the view by expanding a node (Priority: P1)
+
+A user is looking at a focused subset of a large graph and wants to see what is connected to a specific visible node. They act on that node with the intent to expand, and its hidden direct neighbors become visible, along with the edges that connect them to the current view.
+
+**Why this priority**: Without expansion, users have no way to progressively explore a large graph — they must either see everything (overwhelming) or nothing beyond the initial seed. Expansion is the primary exploration primitive.
+
+**Independent Test**: Load a graph, start from a single visible node, perform expand actions on a few nodes in sequence, and verify that each action adds only the direct neighbors of the acted-on node without moving nodes that were already visible.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visible node with N hidden direct neighbors, **When** the user triggers expand on that node, **Then** those N neighbors become visible with the edges connecting them to the visible set.
+2. **Given** a visible node whose neighbors are all already visible, **When** the user triggers expand, **Then** the graph is unchanged and the user sees a non-disruptive indication that there is nothing to expand.
+3. **Given** a shaped graph, **When** the user expands any node, **Then** the positions of nodes that were already on screen are preserved (no global re-layout).
+4. **Given** a node whose expansion would reveal an unusually large number of new neighbors, **When** the user triggers expand, **Then** the user is warned and must explicitly confirm before the expansion commits.
+
+---
+
+### User Story 2 - Shrink the view by collapsing a node (Priority: P1)
+
+A user has pulled too many neighbors into the view or wants to clean up around a specific node. They act on that node with the intent to collapse, and neighbors whose presence in the view is solely due to having been expanded through this node are hidden again; neighbors held in place by other reasons stay.
+
+**Why this priority**: Expansion without a matching collapse is a ratchet — the view only grows. Collapse is the essential inverse, required to let users undo specific expansions locally without resetting the whole view.
+
+**Independent Test**: Shape a graph by expanding two separate anchor nodes such that they share some neighbors, then collapse one of those anchors and verify that shared neighbors remain while anchor-exclusive neighbors disappear.
+
+**Acceptance Scenarios**:
+
+1. **Given** a node whose neighbors were brought in only through this node, **When** the user triggers collapse on that node, **Then** those neighbor nodes are hidden while the collapsed node itself remains visible.
+2. **Given** a neighbor that is visible for multiple reasons (expanded from several anchors, or part of the initial seed), **When** one of its anchors is collapsed, **Then** the neighbor remains visible because other reasons still hold.
+3. **Given** a shaped graph, **When** the user collapses any node, **Then** the positions of the remaining visible nodes are preserved (no global re-layout).
+4. **Given** a seed/initial node, **When** the user triggers collapse on it, **Then** the node itself remains visible; only neighbors brought in through its own expansion are affected.
+
+---
+
+### User Story 3 - Know which nodes are expandable (Priority: P2)
+
+Before clicking, a user wants to see at a glance which visible nodes still have hidden neighbors and which are fully expanded. This turns expand/collapse from guesswork into directed exploration.
+
+**Why this priority**: Affordance for expand is useful once the core expand/collapse works. Without it, users click blindly; with it, they can navigate purposefully. Valuable but additive.
+
+**Independent Test**: In a shaped graph, verify that each visible node displays a clear indicator of whether expanding it would reveal anything new, and that the indicator updates correctly as neighbors are expanded or collapsed elsewhere.
+
+**Acceptance Scenarios**:
+
+1. **Given** a shaped graph, **When** the view is rendered, **Then** each visible node shows whether it currently has hidden direct neighbors.
+2. **Given** an expand or collapse action somewhere in the graph, **When** the action completes, **Then** all affected nodes' expandable indicators update to reflect the new state.
+
+---
+
+### User Story 4 - Reset the view to the default (Priority: P2)
+
+After extensive shaping, a user wants to discard their modifications and return to the graph's default initial presentation without reloading the page.
+
+**Why this priority**: Needed for recovery and for restarting exploration, but only after the shaping primitives themselves work.
+
+**Independent Test**: Shape a graph arbitrarily, trigger reset, verify the view is identical to a fresh load.
+
+**Acceptance Scenarios**:
+
+1. **Given** a shaped graph, **When** the user triggers reset, **Then** the view returns to the graph's default initial state (same visible set and layout as a fresh load).
+
+---
+
+### Edge Cases
+
+- **Expand on a node with no hidden neighbors**: no change, non-disruptive feedback.
+- **Expand would add an unusually large number of neighbors**: user is warned and can confirm or cancel before the expansion commits.
+- **Collapse of a node that is itself visible only because of another expansion**: the collapse hides its anchor-exclusive neighbors; the node itself follows the standard anchor rules (visible as long as any reason still holds).
+- **Collapse of a seed/initial node**: its own visibility is unaffected by collapsing itself; only its direct neighbors brought in by its own expansion are re-hidden.
+- **Circular expansion paths (A expanded B, B expanded A)**: a node is visible if at least one anchor still holds it; collapsing one anchor does not remove nodes kept alive by another.
+- **Repeated expand on the same node after the underlying data has changed**: the expand uses the currently-available neighbors, not a frozen set from an earlier expansion.
+- **Expand/collapse while an automatic initial layout is still settling**: user actions are queued or handled without producing inconsistent visible state.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Users MUST be able to trigger an expand action on any visible node, which reveals that node's direct neighbors that are not currently visible and the edges connecting them to the visible set.
+- **FR-002**: Users MUST be able to trigger a collapse action on any visible node, which hides neighbors whose presence in the view is solely due to having been expanded through this node.
+- **FR-003**: The system MUST preserve the on-screen positions of nodes that were already visible when an expand or collapse action occurs; no global re-layout of unaffected nodes.
+- **FR-004**: The system MUST show, for each visible node, whether it currently has hidden direct neighbors (whether expanding it would change anything).
+- **FR-005**: The system MUST provide a way to reset the shaped view back to the graph's default initial state.
+- **FR-006**: The system MUST warn the user before an expand action brings in an unusually large number of new nodes at once and require explicit confirmation to proceed.
+- **FR-007**: The system MUST keep a visible node on screen as long as at least one reason to show it still holds (initial seed membership, or an expansion anchor that has not been collapsed).
+
+### Key Entities
+
+- **Visible Set**: The subset of the underlying graph currently shown — the nodes and the edges between them — derived from the initial default set plus the user's expand/collapse actions.
+- **Expansion Anchor**: A record that a given visible node was pulled into the view because of an expand action on another node. Multiple anchors can reference the same neighbor. Used to decide what collapse should remove vs. keep.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Starting from the default view of a graph of ≥200 nodes, a user can reach a focused subset of interest using only expand/collapse clicks in under 2 minutes.
+- **SC-002**: After any expand or collapse action, previously visible nodes remain within 5 pixels of their prior position in 100% of cases.
+- **SC-003**: In a graph where two anchors share neighbors, collapsing one anchor leaves the shared neighbors visible in 100% of cases and removes only the anchor-exclusive neighbors.
+- **SC-004**: Users can identify which visible nodes have hidden neighbors without clicking, in under 1 second of inspection, in 100% of cases.
+- **SC-005**: The reset action returns the view to a state indistinguishable from a fresh page load in 100% of cases.
+
+## Assumptions
+
+- The browser already provides a visual graph renderer with draggable nodes and automatic initial layout; this feature adds shaping on top of that renderer.
+- "Neighbors" for expand/collapse means direct (1-hop) neighbors in the underlying graph. Multi-hop expansion policies are out of scope.
+- The initial visible set when a graph is first opened is determined by existing configuration (e.g. the graph's default view) and is not redefined by this feature.
+- Portability of a shaped view (export, import, sharing, sequencing into tours) is a separate concern, covered by its own specification; this spec is only about in-session shaping.
+- Mobile/touch interaction is out of scope for v1; interactions are specified for a pointer device.

--- a/src/FFI/Theme.js
+++ b/src/FFI/Theme.js
@@ -1,0 +1,13 @@
+export const getSystemTheme = () => {
+  var media = window.matchMedia
+    ? window.matchMedia("(prefers-color-scheme: light)")
+    : null;
+  return media && media.matches ? "light" : "dark";
+};
+
+export const applyTheme = (theme) => () => {
+  var resolved = theme === "light" ? "light" : "dark";
+  var root = document.documentElement;
+  root.setAttribute("data-theme", resolved);
+  root.style.colorScheme = resolved;
+};

--- a/src/FFI/Theme.purs
+++ b/src/FFI/Theme.purs
@@ -1,0 +1,12 @@
+module FFI.Theme
+  ( getSystemTheme
+  , applyTheme
+  ) where
+
+import Prelude
+
+import Effect (Effect)
+
+foreign import getSystemTheme :: Effect String
+
+foreign import applyTheme :: String -> Effect Unit

--- a/src/FFI/Url.js
+++ b/src/FFI/Url.js
@@ -45,3 +45,19 @@ export const setBranchParam = (branch) => () => {
   }
   history.replaceState(null, "", url);
 };
+
+export const getThemeParam = () => {
+  var params = new URLSearchParams(window.location.search);
+  var theme = params.get("theme");
+  return theme || "";
+};
+
+export const setThemeParam = (theme) => () => {
+  var url = new URL(window.location);
+  if (theme === "") {
+    url.searchParams.delete("theme");
+  } else {
+    url.searchParams.set("theme", theme);
+  }
+  history.replaceState(null, "", url);
+};

--- a/src/FFI/Url.purs
+++ b/src/FFI/Url.purs
@@ -5,6 +5,8 @@ module FFI.Url
   , setViewParam
   , getBranchParam
   , setBranchParam
+  , getThemeParam
+  , setThemeParam
   ) where
 
 import Prelude
@@ -22,3 +24,7 @@ foreign import setViewParam :: String -> Effect Unit
 foreign import getBranchParam :: Effect String
 
 foreign import setBranchParam :: String -> Effect Unit
+
+foreign import getThemeParam :: Effect String
+
+foreign import setThemeParam :: String -> Effect Unit

--- a/src/Persist.purs
+++ b/src/Persist.purs
@@ -12,6 +12,8 @@ module Persist
   , saveToken
   , loadToken
   , deleteToken
+  , saveThemePreference
+  , loadThemePreference
   ) where
 
 import Prelude
@@ -140,3 +142,21 @@ deleteToken repoId = do
   w <- Web.HTML.window
   storage <- Window.localStorage w
   Storage.removeItem (tokenKey repoId) storage
+
+themeKey :: String
+themeKey = "graph-browser:theme"
+
+saveThemePreference :: String -> Effect Unit
+saveThemePreference theme = do
+  w <- Web.HTML.window
+  storage <- Window.localStorage w
+  if theme == "" then
+    Storage.removeItem themeKey storage
+  else
+    Storage.setItem themeKey theme storage
+
+loadThemePreference :: Effect (Maybe String)
+loadThemePreference = do
+  w <- Web.HTML.window
+  storage <- Window.localStorage w
+  Storage.getItem themeKey storage

--- a/src/Viewer.purs
+++ b/src/Viewer.purs
@@ -17,6 +17,8 @@ import Effect.Aff (Aff, try)
 import Effect.Aff.Class (liftAff)
 import Effect.Class (liftEffect)
 import FFI.Cytoscape as Cy
+import FFI.Theme as Theme
+import FFI.Url as Url
 import Fetch (Method(..), fetch)
 import Graph.Cytoscape as GCy
 import Graph.Operations (filterBySources, neighborhood, subgraph)
@@ -90,6 +92,7 @@ viewer = H.mkComponent
       , graph: emptyGraph
       , fullGraph: emptyGraph
       , dataUrls: urls
+      , theme: "dark"
       , selected: Nothing
       , hoveredNode: Nothing
       , hoveredEdge: Nothing
@@ -219,6 +222,16 @@ handleAction
   -> H.HalogenM State Action () o Aff Unit
 handleAction = case _ of
   Initialize -> do
+    urlTheme <- liftEffect Url.getThemeParam
+    storedTheme <- liftEffect Persist.loadThemePreference
+    systemTheme <- liftEffect Theme.getSystemTheme
+    let
+      requestedTheme =
+        resolveThemePreference urlTheme storedTheme
+      currentTheme =
+        resolveTheme requestedTheme systemTheme
+    liftEffect $ Theme.applyTheme currentTheme
+    H.modify_ _ { theme = currentTheme }
     state0 <- H.get
     let urls = state0.dataUrls
     cfgResult <- liftAff (loadConfig urls.configUrl)
@@ -493,6 +506,14 @@ handleAction = case _ of
 
   FitAll ->
     liftEffect Cy.fitAll
+
+  ToggleTheme -> do
+    currentTheme <- H.gets _.theme
+    let nextTheme = toggleTheme currentTheme
+    liftEffect $ Theme.applyTheme nextTheme
+    liftEffect $ Persist.saveThemePreference nextTheme
+    liftEffect $ Url.setThemeParam nextTheme
+    H.modify_ _ { theme = nextTheme }
 
   ToggleTutorialMenu ->
     H.modify_ \s -> s
@@ -997,3 +1018,35 @@ mergeKinds base extra =
     (\acc (Tuple kindId kindDef) -> Map.insert kindId kindDef acc)
     base
     (Map.toUnfoldable extra :: Array (Tuple KindId KindDef))
+
+normalizeTheme :: String -> String
+normalizeTheme theme =
+  if theme == "light" then "light"
+  else "dark"
+
+normalizeThemePreference :: String -> Maybe String
+normalizeThemePreference theme
+  | theme == "light" = Just "light"
+  | theme == "dark" = Just "dark"
+  | theme == "auto" = Just "auto"
+  | otherwise = Nothing
+
+resolveThemePreference :: String -> Maybe String -> String
+resolveThemePreference urlTheme storedTheme =
+  case normalizeThemePreference urlTheme of
+    Just theme -> theme
+    Nothing -> case storedTheme >>= normalizeThemePreference of
+      Just theme -> theme
+      Nothing -> "auto"
+
+resolveTheme :: String -> String -> String
+resolveTheme requested systemTheme =
+  case requested of
+    "light" -> "light"
+    "dark" -> "dark"
+    _ -> normalizeTheme systemTheme
+
+toggleTheme :: String -> String
+toggleTheme theme =
+  if normalizeTheme theme == "light" then "dark"
+  else "light"

--- a/src/Viewer/Controls.purs
+++ b/src/Viewer/Controls.purs
@@ -46,7 +46,8 @@ renderControls
   :: forall m. State -> H.ComponentHTML Action () m
 renderControls state =
   HH.div [ cls "controls" ]
-    [ if not (Array.null state.viewIndex) then
+    [ renderThemeToggle state
+    , if not (Array.null state.viewIndex) then
         HH.div [ cls "tour-menu-wrapper" ]
           [ HH.button
               [ cls "control-btn"
@@ -86,6 +87,25 @@ renderControls state =
             [ HH.text "All" ]
         ]
     ]
+
+renderThemeToggle
+  :: forall m. State -> H.ComponentHTML Action () m
+renderThemeToggle state =
+  HH.button
+    [ cls "control-btn theme-toggle-btn"
+    , HP.attr (HH.AttrName "aria-label") label
+    , HP.attr (HH.AttrName "title") label
+    , HE.onClick \_ -> ToggleTheme
+    ]
+    [ HH.text icon ]
+  where
+  isLight = state.theme == "light"
+  label =
+    if isLight then "Switch to dark theme"
+    else "Switch to light theme"
+  icon =
+    if isLight then "☾"
+    else "☀"
 
 renderLegend
   :: forall m. Config -> H.ComponentHTML Action () m

--- a/src/Viewer/Types.purs
+++ b/src/Viewer/Types.purs
@@ -50,6 +50,7 @@ type State =
   , graph :: Graph
   , fullGraph :: Graph
   , dataUrls :: DataUrls
+  , theme :: String
   , selected :: Maybe Node
   , hoveredNode :: Maybe Node
   , hoveredEdge :: Maybe EdgeInfo
@@ -99,6 +100,7 @@ data Action
   | SetSearch String
   | SelectSearchResult SearchResult
   | FitAll
+  | ToggleTheme
   | NavigateTo String
   | ToggleTutorialMenu
   | StartTutorial String


### PR DESCRIPTION
Closes #80

## What changed

This adds a visible dark/light theme toggle to the shared viewer controls so embedded deployments such as Cardano Knowledge Maps expose an in-page way to switch themes.

The change keeps the project aligned with the constitution:

- theme selection and persistence now live in PureScript viewer state
- JavaScript remains thin browser FFI for reading system theme and applying the resolved theme to `document.documentElement`
- the static HTML bootstrap only handles first-paint theme resolution from `?theme=` or persisted preference so the page does not flash in the wrong theme before Halogen mounts

## Implementation notes

- added `theme` to viewer state plus a `ToggleTheme` action
- render a compact theme button in the controls row
- initialize theme from URL override, then persisted preference, then system theme
- persist manual theme changes in `localStorage`
- keep the URL param in sync when the user toggles so links remain shareable and explicit overrides still work
- added thin `FFI.Theme` and extended `FFI.Url` with `getThemeParam` / `setThemeParam`

## Verification

- `nix develop --quiet -c just test`
- `nix develop --quiet -c just bundle-lib`
- headless Chromium check against the built viewer loaded with Cardano Knowledge Maps data:
  - default load renders `.theme-toggle-btn`
  - clicking the button flips `data-theme` and updates `?theme=`
  - loading `?theme=dark` shows `☀` with title `Switch to light theme`

## Reviewer focus

- confirm the control placement in the top-left viewer controls is acceptable for both app and lib variants
- confirm persisting explicit dark/light selection is preferable to cycling through an `auto` mode in the UI
- confirm downstream consumers only need a rebuild/redeploy to pick up the new control
