### PR TITLE
feat: add selectable graph layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An interactive knowledge graph browser with guided tours. Graph data is declared
 
 ## Features
 
-- Force-directed graph layout (fCoSE) with adaptive spacing
+- Selectable graph layouts: fCoSE, ELK, Cola, Dagre, Concentric
 - Click to focus, depth controls (1/2/3/All) for neighborhood size
 - Hover nodes and edges for descriptions
 - Full-text search across all labels and descriptions
@@ -14,7 +14,7 @@ An interactive knowledge graph browser with guided tours. Graph data is declared
 - Fully data-driven: title, kinds, colors, shapes all from config
 - **Universal viewer**: browse any repo's graph via `?repo=owner/repo`
 - **Repo management**: add, switch, and delete repos from a left panel
-- **Per-repo state**: each repo remembers selected node, depth, tutorial progress
+- **Per-repo state**: each repo remembers selected node, depth, tutorial progress, and explicit layout choice
 - **Dual output**: `lib` (embeddable viewer) and `app` (hosted universal viewer)
 - **Deep-linking**: share `?repo=owner/repo` URLs that auto-load
 - **Token support**: encrypted storage for private repo access
@@ -126,6 +126,25 @@ In this mode:
 }
 ```
 
+### `data/queries.json` (optional)
+
+Query catalog entries can drive the left-hand query panel. Queries tagged with `"view"` act as named graph views, and can declare an optional default layout.
+
+```json
+[
+  {
+    "id": "build-validation",
+    "name": "Build & Validation",
+    "description": "CI and validation flow.",
+    "sparql": "SELECT ?node WHERE { ?node ?p ?o }",
+    "tags": ["view"],
+    "layout": "dagre"
+  }
+]
+```
+
+Supported layout IDs are `fcose`, `elk`, `cola`, `dagre`, and `concentric`. An authored `layout` is the default for that view until the user explicitly picks a different layout for the repo.
+
 ### `data/views/<name>.json` (optional)
 
 Views filter the graph into topic-specific subgraphs. Each view selects edges by triple and includes its own tours.
@@ -134,6 +153,7 @@ Views filter the graph into topic-specific subgraphs. Each view selects edges by
 {
   "name": "My Topic",
   "description": "A focused lens on this topic.",
+  "layout": "concentric",
   "edges": [
     ["node-a", "node-b", "relates to"],
     ["node-c", "node-d", "depends on"]
@@ -150,6 +170,8 @@ Views filter the graph into topic-specific subgraphs. Each view selects edges by
   ]
 }
 ```
+
+Legacy view files also support the same optional `layout` field and layout IDs as `data/queries.json`.
 
 A `data/views/index.json` listing available views must also be committed:
 
@@ -306,6 +328,7 @@ That gives downstream applications an explicit contract: they are free to define
 Validate your data against the schemas in [`schema/`](schema/):
 
 - [`config.schema.json`](schema/config.schema.json) — configuration
+- [`query-catalog.schema.json`](schema/query-catalog.schema.json) — query catalog and query-backed views
 - [`tutorial.schema.json`](schema/tutorial.schema.json) — guided tour
 - [`tutorial-index.schema.json`](schema/tutorial-index.schema.json) — tour list
 - [`view.schema.json`](schema/view.schema.json) — view (subgraph lens with tours)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.0",
       "dependencies": {
         "cytoscape": "^3.33.1",
+        "cytoscape-cola": "^2.5.1",
+        "cytoscape-dagre": "^2.5.0",
+        "cytoscape-elk": "^2.3.0",
         "cytoscape-fcose": "^2.2.0",
         "oxigraph": "^0.5.6"
       }
@@ -27,8 +30,45 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cola": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/cytoscape-cola/-/cytoscape-cola-2.5.1.tgz",
+      "integrity": "sha512-4/2S9bW1LvdsEPmxXN1OEAPFPbk7DvCx2c9d+TblkQAAvptGaSgtPWCByTEGgT8UxCxcVqes2aFPO5pzwo7R2w==",
+      "license": "MIT",
+      "dependencies": {
+        "webcola": "^3.4.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-dagre": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-dagre/-/cytoscape-dagre-2.5.0.tgz",
+      "integrity": "sha512-VG2Knemmshop4kh5fpLO27rYcyUaaDkRw+6PiX4bstpB+QFt0p2oauMrsjVbUamGWQ6YNavh7x2em2uZlzV44g==",
+      "license": "MIT",
+      "dependencies": {
+        "dagre": "^0.8.5"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.22"
+      }
+    },
+    "node_modules/cytoscape-elk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-elk/-/cytoscape-elk-2.3.0.tgz",
+      "integrity": "sha512-1h2ZmPOy5HD2+mrfF3P2ICxfnDyPCWg/xLVs7fIjTOzdQu51ydrMtm6Sb7KnhFwLBzhGIVYI2Gbns0njggBarQ==",
+      "license": "MIT",
+      "dependencies": {
+        "elkjs": "^0.9.3"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
       }
     },
     "node_modules/cytoscape-fcose": {
@@ -43,10 +83,84 @@
         "cytoscape": "^3.2.0"
       }
     },
+    "node_modules/d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-drag": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz",
+      "integrity": "sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1",
+        "d3-selection": "1"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-selection": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/elkjs": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
+      "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
+      "license": "EPL-2.0"
+    },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
     "node_modules/layout-base": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
       "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/oxigraph": {
@@ -54,6 +168,18 @@
       "resolved": "https://registry.npmjs.org/oxigraph/-/oxigraph-0.5.6.tgz",
       "integrity": "sha512-tACXVQY7lpQ5Nx9vrIpl9sdFMXPOhx9bS3ET5OU+t18IqKsapsk6JtL4LMKZMoU0D0Vn0VA6STGqt8Elmy5Pjw==",
       "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/webcola": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/webcola/-/webcola-3.4.0.tgz",
+      "integrity": "sha512-4BiLXjXw3SJHo3Xd+rF+7fyClT6n7I+AR6TkBqyQ4kTsePSAMDLRCXY1f3B/kXJeP9tYn4G1TblxTO+jAt0gaw==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-dispatch": "^1.0.3",
+        "d3-drag": "^1.0.4",
+        "d3-shape": "^1.3.5",
+        "d3-timer": "^1.0.5"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   },
   "dependencies": {
     "cytoscape": "^3.33.1",
+    "cytoscape-cola": "^2.5.1",
+    "cytoscape-dagre": "^2.5.0",
+    "cytoscape-elk": "^2.3.0",
     "cytoscape-fcose": "^2.2.0",
     "oxigraph": "^0.5.6"
   }

--- a/schema/query-catalog.schema.json
+++ b/schema/query-catalog.schema.json
@@ -57,6 +57,11 @@
         "items": { "type": "string" },
         "default": [],
         "description": "Tags for categorization (e.g. 'view', 'tour:guide-name')."
+      },
+      "layout": {
+        "type": "string",
+        "enum": ["fcose", "elk", "cola", "dagre", "concentric"],
+        "description": "Optional default layout when this query is used as a view."
       }
     },
     "additionalProperties": false

--- a/schema/view.schema.json
+++ b/schema/view.schema.json
@@ -15,6 +15,11 @@
       "type": "string",
       "description": "Short description shown in the view picker."
     },
+    "layout": {
+      "type": "string",
+      "enum": ["fcose", "elk", "cola", "dagre", "concentric"],
+      "description": "Optional default layout for this view."
+    },
     "edges": {
       "type": "array",
       "description": "Edge references as [source, target, label] triples.",

--- a/specs/012-layout-picker/data-model.md
+++ b/specs/012-layout-picker/data-model.md
@@ -1,0 +1,151 @@
+# Data Model: User-Selectable Graph Layouts
+
+## LayoutId
+
+The canonical viewer layout identifier.
+
+```text
+LayoutId =
+  "fcose"
+  | "elk"
+  | "cola"
+  | "dagre"
+  | "concentric"
+```
+
+## LayoutSource
+
+Tracks why the current layout is active.
+
+```text
+LayoutSource =
+  "saved-explicit"
+  | "view-default"
+  | "fallback"
+```
+
+This distinction matters because authored defaults should apply only until the user makes an explicit choice for that repo.
+
+## ViewerLayoutState
+
+Runtime layout state held in `Viewer.Types.State`.
+
+```text
+ViewerLayoutState:
+  activeLayout: LayoutId
+  layoutSource: LayoutSource
+```
+
+### Semantics
+
+- `activeLayout` is the layout currently rendered in Cytoscape
+- `layoutSource` distinguishes user intent from derived defaults
+- `layoutSource = "saved-explicit"` tells view-selection logic not to override the user with authored defaults
+
+## RepoLayoutPreference
+
+Stored separately from the existing `PersistedState`.
+
+```text
+RepoLayoutPreference:
+  identity: String
+  layout: LayoutId
+```
+
+### Identity derivation
+
+```text
+identity =
+  if dataUrls.baseUrl is a raw GitHub repo URL then "<owner>/<repo>"
+  else if dataUrls.baseUrl != "" then dataUrls.baseUrl
+  else if config.sourceUrl != "" then config.sourceUrl
+  else config.title
+```
+
+This keeps app-mode preferences repo-scoped across branch previews without forcing a wider migration of existing title-keyed state.
+
+## ViewLayoutDefault
+
+Optional authored layout attached to a view-like artifact.
+
+```text
+ViewLayoutDefault:
+  layout: Maybe LayoutId
+```
+
+Applies to:
+
+- a query-catalog entry tagged as a view
+- a legacy view JSON file loaded through `Graph.Views`
+
+## Query-Backed View Shape
+
+Existing view-like queries gain an optional `layout` field.
+
+```json
+{
+  "id": "module-flow",
+  "name": "Module Flow",
+  "description": "Directed flow through the major modules",
+  "sparql": "SELECT ?node WHERE { ... }",
+  "tags": ["view"],
+  "layout": "dagre"
+}
+```
+
+## Legacy View Shape
+
+Legacy view JSON files also gain an optional `layout` field.
+
+```json
+{
+  "name": "Architecture Rings",
+  "description": "Grouped by concern",
+  "layout": "concentric",
+  "edges": [
+    ["viewer", "query-panel", "contains"]
+  ],
+  "tours": []
+}
+```
+
+## Precedence Rules
+
+```text
+effectiveLayout(view) =
+  saved explicit layout for repo
+  else authored layout on active view
+  else "fcose"
+```
+
+### Trigger rules
+
+- On initial viewer load:
+  - restore saved layout if present
+  - otherwise use `fcose`
+- On activating a view:
+  - if a saved explicit repo layout exists, keep it
+  - otherwise apply the view's authored layout if present
+  - otherwise keep fallback `fcose`
+- On explicit user layout change:
+  - update `activeLayout`
+  - set `layoutSource = "saved-explicit"`
+  - persist the layout under the repo identity key
+
+## Persistence Shape
+
+Recommended localStorage entry:
+
+```json
+{
+  "layout": "elk"
+}
+```
+
+Stored under a dedicated key:
+
+```text
+graph-browser:layout:<identity>
+```
+
+This avoids changing the existing persisted viewer-state schema for node/depth/tutorial restore.

--- a/specs/012-layout-picker/plan.md
+++ b/specs/012-layout-picker/plan.md
@@ -1,0 +1,131 @@
+# Implementation Plan: User-Selectable Graph Layouts
+
+**Branch**: `012-layout-picker` | **Date**: 2026-04-23 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/012-layout-picker/spec.md`
+
+## Summary
+
+Add a real layout model to the viewer so users can switch among multiple Cytoscape layouts at runtime, persist their explicit choice per repo, and let curated views declare an optional default layout for first-time visitors. The implementation should keep layout state inside the shared viewer, register additional Cytoscape layout engines in the bundle, and use a dedicated layout-preference store instead of changing the existing node/depth/tutorial persistence contract.
+
+## Technical Context
+
+**Language/Version**: PureScript (Spago) with JavaScript FFI and npm Cytoscape plugins  
+**Primary Dependencies**: Halogen, Cytoscape.js, `cytoscape-fcose`, additional Cytoscape layout extensions  
+**Storage**: Browser `localStorage` for repo layout preferences  
+**Testing**: `just test`, `just bundle-app`, `just bundle-lib`, manual browser verification on self graph and a downstream repo  
+**Target Platform**: Browser, GitHub Pages hosted app, embeddable lib bundle  
+**Project Type**: Frontend viewer plus static bundles  
+**Performance Goals**: Layout switching should reflow the current graph in-session without requiring data reload  
+**Constraints**: Preserve active browsing context; keep app/lib behavior aligned; avoid regressing existing persisted viewer-state restore  
+**Scale/Scope**: Viewer controls, Cytoscape FFI, query/view metadata, bundle dependencies, and layout-specific persistence only
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Data-Driven, Zero Hardcoding | PASS | Available layouts are product-level viewer behavior; authored defaults still live in data files |
+| II. PureScript for Logic, JS FFI for Rendering | PASS | Layout selection logic stays in PureScript; JS remains a thin Cytoscape bridge |
+| III. Nix-First Builds | PASS | New layout engines enter through npm lockfile and existing Nix bundle flow |
+| IV. Library/App Split | PASS | Layout behavior belongs in shared viewer code and must work in both `Main` and `Lib` |
+| V. Schema-Validated Data | PASS | Query-catalog and view schemas gain explicit optional `layout` fields |
+| VI. Accessibility of Information | PASS | Different graph shapes become easier to read without forcing one layout on every dataset |
+
+## Project Structure
+
+```text
+src/
+├── Viewer.purs                  # MODIFY: restore/apply effective layout during init and view/query changes
+├── Viewer/Types.purs            # MODIFY: add layout state and actions
+├── Viewer/Controls.purs         # MODIFY: render the layout selector in the control bar
+├── Persist.purs                 # MODIFY: add dedicated layout preference save/load helpers
+├── FFI/Cytoscape.purs           # MODIFY: expose layout-aware render/relayout functions
+├── FFI/Cytoscape.js             # MODIFY: register, select, and run multiple layouts
+├── Graph/Query.purs             # MODIFY: decode optional layout on query-backed views
+├── Graph/Views.purs             # MODIFY: decode optional layout on legacy view files
+└── bootstrap.js                 # MODIFY: register additional Cytoscape layout engines
+
+schema/
+├── query-catalog.schema.json    # MODIFY: optional layout field for view-like queries
+└── view.schema.json             # MODIFY: optional layout field for legacy views
+
+package.json                     # MODIFY: add Cytoscape layout extension deps
+package-lock.json                # MODIFY: lock layout extension deps
+README.md                        # REVIEW/MODIFY: document supported layout ids if user-facing docs need parity
+```
+
+## Design Decisions
+
+### D1: Keep layout persistence separate from existing viewer restore state
+
+Do not repurpose `PersistedState` for this feature. Add dedicated layout preference helpers keyed by a repo/viewer identity derived from parsed `owner/repo` when `baseUrl` is a raw GitHub repo URL, then `baseUrl`, then `sourceUrl`, then `title`.
+
+### D2: Treat layout as shared viewer state, not a Cytoscape-only detail
+
+Add `activeLayout` and `layoutSource` to `Viewer.Types.State` so layout precedence is explicit and testable in PureScript.
+
+### D3: Authored defaults belong on views, not on arbitrary queries
+
+Add optional `layout` support to:
+
+- query-catalog entries tagged as `"view"`
+- legacy view JSON files
+
+Non-view queries keep working without layout metadata.
+
+### D4: Support both rerender and in-place relayout paths
+
+The Cytoscape FFI should have one active layout concept that is reused by graph renders, plus a direct relayout path for explicit user switching. This avoids duplicating layout logic and makes it easier to preserve selection state.
+
+### D5: Explicit user choice outranks authored defaults
+
+The effective layout order is:
+
+1. saved explicit repo layout
+2. authored default of the currently active view when no saved explicit layout exists
+3. `fcose` fallback
+
+Authored defaults are derived behavior and should not be persisted as if the user chose them.
+
+## Implementation Phases
+
+### Phase 1: Layout State, Persistence, and Data Shapes
+
+- Add layout state and actions to `Viewer/Types.purs`
+- Add dedicated layout preference save/load helpers to `Persist.purs`
+- Extend `Graph.Query.NamedQuery` and `Graph.Views.View` with optional layout metadata
+- Extend `schema/query-catalog.schema.json` and `schema/view.schema.json` with the same optional field
+
+### Phase 2: Cytoscape Layout Engine Support
+
+- Add the required Cytoscape layout extension dependencies to `package.json` / `package-lock.json`
+- Register those engines in `src/bootstrap.js`
+- Refactor `FFI/Cytoscape.js` so layout execution is selected by `LayoutId` instead of hardcoded to `fcose`
+- Expose the necessary PureScript FFI hooks for applying and rerunning the active layout
+
+### Phase 3: Viewer Behavior and Controls
+
+- Add a layout selector to `Viewer/Controls.purs`
+- Restore the saved explicit layout during initialization when present
+- Apply authored defaults when selecting a view and no saved explicit layout exists
+- Preserve node and edge selection styling when layout changes
+- Ensure query execution, view selection, tutorial movement, and source filtering continue to render through the active layout
+
+### Phase 4: Verification and Documentation
+
+- Run `just test`
+- Bundle both app and lib outputs
+- Manually verify on graph-browser’s self graph and at least one downstream repo
+- Update user-facing docs if the supported layout ids or authoring shape need to be documented
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Layout switching via full rerender drops edge highlight | User-visible regression | Replay selected-edge styling after rerender or prefer a direct relayout path |
+| Saved layout keyed too broadly or too narrowly | Wrong repo restores wrong layout | Use a dedicated identity derived from canonical `owner/repo` when possible, with explicit fallbacks |
+| Layout engines differ in option shapes and animation behavior | Uneven UX across engines | Centralize layout option mapping in `FFI/Cytoscape.js` and start with conservative defaults |
+| Query-backed and legacy views drift in supported metadata | Inconsistent authoring story | Add the same optional `layout` field to both decoding paths and both schemas |
+
+## Dependencies
+
+- Issue `#68` is related but not blocking: this feature only needs to react when a view becomes active; wiring `?view=` to activate a view is a separate concern

--- a/specs/012-layout-picker/quickstart.md
+++ b/specs/012-layout-picker/quickstart.md
@@ -1,0 +1,83 @@
+# Quickstart: Verify User-Selectable Graph Layouts
+
+## 1. Install and build
+
+```bash
+npm ci
+just test
+just bundle-app
+just bundle-lib
+```
+
+## 2. Verify layout switching on the self graph
+
+Open the bundled app or a local dev session on the graph-browser self graph.
+
+Check that:
+
+- the controls expose `fCoSE`, `ELK`, `Cola`, `Dagre`, and `Concentric`
+- switching layouts reflows the current visible graph without refetching data
+- node selection, edge selection, active query/view, and tutorial step remain active after the relayout
+
+## 3. Verify repo-scoped persistence
+
+Use two repos in the hosted app flow.
+
+Example:
+
+- repo A: `lambdasistemi/graph-browser`
+- repo B: `lambdasistemi/zk-lab`
+
+Check that:
+
+- choosing `Dagre` in repo A does not force repo B to use `Dagre`
+- choosing `Concentric` in repo B does not overwrite repo A
+- reloading the app restores each repo’s last explicit layout
+
+## 4. Verify authored defaults
+
+Create one query-backed view and one legacy view with explicit layout defaults.
+
+Example query-backed view entry:
+
+```json
+{
+  "id": "chapter-flow",
+  "name": "Chapter Flow",
+  "description": "A directed walkthrough",
+  "sparql": "SELECT ?node WHERE { ... }",
+  "tags": ["view"],
+  "layout": "dagre"
+}
+```
+
+Example legacy view file:
+
+```json
+{
+  "name": "Schema Rings",
+  "description": "Grouped by ontology concern",
+  "layout": "concentric",
+  "edges": [
+    ["class-a", "class-b", "subClassOf"]
+  ],
+  "tours": []
+}
+```
+
+For a first-time visitor with no saved layout preference, verify that:
+
+- selecting the query-backed view activates `Dagre`
+- selecting the legacy view activates `Concentric`
+
+After explicitly choosing another layout, verify that reopening those views keeps the saved explicit layout instead of reapplying the authored defaults.
+
+## 5. Verify fallback behavior
+
+Check that invalid authored or saved layout identifiers never block rendering.
+
+Expected behavior:
+
+- the graph still renders
+- the viewer falls back to `fCoSE`
+- the controls show the fallback layout as active

--- a/specs/012-layout-picker/research.md
+++ b/specs/012-layout-picker/research.md
@@ -1,0 +1,125 @@
+# Research: User-Selectable Graph Layouts
+
+## Current Rendering Path
+
+- `src/bootstrap.js` imports `cytoscape` and registers only `cytoscape-fcose`
+- `src/FFI/Cytoscape.js` hardcodes `name: "fcose"` inside `runLayout`
+- `src/FFI/Cytoscape.purs` exposes graph replacement and fit helpers, but no layout-selection or relayout API
+- `src/Viewer.purs` always renders through `renderGraph`, which calls `Cy.setFocusElements` and then re-marks the selected root node
+
+### Consequences
+
+- The viewer has no representation of “current layout” today
+- Any new layout choice must be carried through the Cytoscape FFI, not just added as a UI label
+- Layout switching can be implemented either by:
+  - adding a dedicated relayout API that operates on existing elements, or
+  - making every render path pass the active layout into Cytoscape
+
+## Current Selection Behavior
+
+- `renderGraph` re-applies the selected node highlight with `Cy.markRoot`
+- `renderGraph` does not re-apply selected-edge highlighting after replacing elements
+- `selectedEdge` already exists in `Viewer.Types.State`, but render-time replay is incomplete
+
+### Consequences
+
+- A layout switch that replaces graph elements must explicitly restore edge selection styling
+- A relayout-only path is safer for preserving visual state, but the code still needs a single source of truth for the active layout
+
+## Current State and Persistence
+
+- `Viewer.Types.State` currently stores graph, view, query, tutorial, and source-filter state, but no layout state
+- `Persist.PersistedState` stores:
+  - `selectedNodeId`
+  - `depth`
+  - `tutorialId`
+  - `tutorialStep`
+- `Persist.save` / `Persist.restore` use `graph-browser:<title>` as the storage key
+- Repo lists and tokens are already stored separately under repo-specific keys
+- In app mode, `RepoDiscovery` gives the viewer a `baseUrl` rooted at the repo+branch raw GitHub path
+- In lib mode, `Lib.purs` passes `baseUrl: ""`
+
+### Consequences
+
+- Re-keying all viewer persistence from title to repo identity would be broader than this feature and risks regressing existing restore behavior
+- A dedicated layout-preference key is the lowest-risk design
+- Layout identity can be derived in the viewer from:
+  - parsed `owner/repo` when `dataUrls.baseUrl` is a raw GitHub repo URL
+  - otherwise `dataUrls.baseUrl` when present
+  - otherwise `config.sourceUrl` when present
+  - otherwise `config.title`
+
+## Current View and Query Metadata
+
+- Query-backed views are represented as `NamedQuery` entries tagged with `"view"` in `data/queries.json`
+- `Graph.Query.NamedQuery` currently has:
+  - `id`
+  - `name`
+  - `description`
+  - `sparql`
+  - `parameters`
+  - `tags`
+- `schema/query-catalog.schema.json` mirrors that shape and has no layout field
+- Legacy view files decode through `Graph.Views.View`, which currently has:
+  - `name`
+  - `description`
+  - `edges`
+  - `tours`
+- `schema/view.schema.json` also has no layout field
+
+### Consequences
+
+- Authored layout defaults must be added in both places:
+  - query-catalog entries that act as views
+  - legacy view JSON files
+- The feature should not treat every query as a layout-bearing artifact; the authored default only matters for view-like queries
+
+## Bundle and Dependency Surface
+
+- `package.json` / `package-lock.json` currently include:
+  - `cytoscape`
+  - `cytoscape-fcose`
+  - `oxigraph`
+- `src/bootstrap.js` is bundled for both `bundle-app` and `bundle-lib`
+- `flake.nix` uses `importNpmLock.buildNodeModules`, so adding Cytoscape layout extensions is a normal npm lockfile change, not a custom Nix packaging task
+
+### Consequences
+
+- ELK, Cola, and Dagre support belong in npm dependencies plus `src/bootstrap.js` registration
+- `Concentric` is a built-in Cytoscape layout and does not require a separate plugin
+
+## URL and Embed Relationship
+
+- `src/FFI/Url.js` already exposes `getViewParam` / `setViewParam`
+- No PureScript caller uses those functions today
+- Open issue `#68` tracks wiring `?view=<id>` into the actual viewer flow
+
+### Consequences
+
+- This feature should react correctly whenever a view becomes active
+- Deep-linking to a specific view remains a separate activation concern
+- Once issue `#68` lands, the same authored-layout path can be reused on initial load
+
+## Recommended Precedence Model
+
+1. Saved explicit repo layout
+2. Authored default for the currently active view, but only when no saved explicit layout exists
+3. Global fallback `fcose`
+
+### Why this model fits the request
+
+- It preserves user intent once they actively choose a layout
+- It still lets first-time visitors benefit from curated defaults
+- It avoids persisting authored defaults as if they were user choices
+
+## Recommended Scope Boundaries
+
+- Include:
+  - runtime layout switching
+  - per-repo saved layout preference
+  - authored default layout on query-backed and legacy views
+  - both app and lib bundles
+- Exclude:
+  - `?view=` activation itself
+  - changing the rest of viewer persistence away from title-based restore
+  - layout-specific tuning for every dataset beyond a stable first pass

--- a/specs/012-layout-picker/spec.md
+++ b/specs/012-layout-picker/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: User-Selectable Graph Layouts
+
+**Feature Branch**: `012-layout-picker`  
+**Created**: 2026-04-23  
+**Status**: Draft  
+**Input**: GitHub issue #39
+
+## User Scenarios & Testing
+
+### User Story 1 - Switch layout to match the graph shape (Priority: P1)
+
+A user exploring a graph needs to change how the graph is arranged depending on what they are trying to understand. A force-directed layout may be best for general exploration, while a layered or concentric layout may make flows, hierarchies, or groupings clearer. The user can switch layouts from the viewer controls without reloading the graph or losing their place.
+
+**Why this priority**: This is the core feature request. Without in-session layout switching, the browser forces one presentation style onto every graph shape.
+
+**Independent Test**: Load a repo, switch between multiple layouts from the viewer controls, and verify that the visible graph reflows in place while the current repo, selection, and navigation context remain active.
+
+**Acceptance Scenarios**:
+
+1. **Given** a loaded graph, **When** the user chooses a different layout from the viewer controls, **Then** the currently visible graph is rearranged without refetching data or reloading the page
+2. **Given** an active node, edge, query result, or tutorial step, **When** the user switches layouts, **Then** that context remains active after the graph reflows
+3. **Given** a repo with no saved or authored layout preference, **When** the viewer loads, **Then** it starts with the default force-directed layout
+
+---
+
+### User Story 2 - Curated views open with an authored layout default (Priority: P2)
+
+A knowledge-map author curates named views to explain a graph from different angles. Some views read best as flows, some as hierarchies, and some as grouped rings. The author can declare a preferred default layout for a view so first-time users see that view in the most meaningful arrangement immediately.
+
+**Why this priority**: Curated views are part of how graph-browser makes complex information accessible. Layout is part of that presentation, not just a user preference.
+
+**Independent Test**: Configure one query-backed view and one legacy view with authored layout defaults, open them as a first-time visitor, and verify that each view starts in its declared layout.
+
+**Acceptance Scenarios**:
+
+1. **Given** a query-backed view or legacy view with an authored default layout and no saved user preference for that repo, **When** the user opens that view, **Then** the declared layout becomes active automatically
+2. **Given** a deep link or embedded instance that opens a specific view, **When** the view loads for a first-time visitor, **Then** the view appears using its authored default layout without extra clicks
+3. **Given** a view declares an invalid or unsupported layout identifier, **When** the view loads, **Then** the viewer falls back to the default layout and remains usable
+
+---
+
+### User Story 3 - Each repo remembers the user's preferred layout (Priority: P3)
+
+A user browses multiple repos with different graph structures. They want each repo to remember the last layout they explicitly chose, so returning to a familiar graph does not require reconfiguring the presentation every time.
+
+**Why this priority**: Persistence removes repeated setup friction and makes layout choice feel like part of the browsing context, not a temporary tweak.
+
+**Independent Test**: Visit two repos, choose different layouts in each, reload the page or switch away and back, and verify that each repo restores its own last explicit layout choice.
+
+**Acceptance Scenarios**:
+
+1. **Given** repo A was last viewed with one layout and repo B with another, **When** the user switches between those repos, **Then** each repo restores its own saved layout choice
+2. **Given** a user previously chose a layout for a repo, **When** they return to that repo later, **Then** the viewer restores that explicit choice automatically
+3. **Given** a repo already has a saved user layout and a view declares a different authored default, **When** the user reopens that repo, **Then** the saved user choice takes precedence
+
+---
+
+### Edge Cases
+
+- A saved layout identifier is no longer supported by the viewer
+- A view or query definition declares a layout identifier the viewer does not recognize
+- The user switches layouts while a tutorial, query result, or node/edge selection is active
+- The currently visible graph is very small, so two layouts appear visually similar even though the active layout changed
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The viewer MUST expose a layout selector in its graph controls once a graph is loaded
+- **FR-002**: The viewer MUST offer at least these layout choices: `fCoSE`, `ELK`, `Cola`, `Dagre`, and `Concentric`
+- **FR-003**: Changing the active layout MUST rearrange the currently visible graph without reloading the page or refetching repo data
+- **FR-004**: Layout changes MUST preserve the user’s current browsing context, including active repo, selected node or edge, active query or view, tutorial step, depth, and source filters
+- **FR-005**: The system MUST use `fCoSE` as the fallback default layout whenever no other valid layout choice applies
+- **FR-006**: The system MUST persist the user’s last explicit layout choice separately for each repo
+- **FR-007**: The system MUST restore a repo’s saved layout choice when that repo is reopened
+- **FR-008**: Authored view definitions MUST be allowed to declare an optional default layout
+- **FR-009**: “View definitions” MUST include both query-catalog entries used as views and legacy view files
+- **FR-010**: An authored default layout MUST apply for users who do not yet have a saved layout preference for that repo
+- **FR-011**: After a user has made an explicit layout choice for a repo, that saved choice MUST override authored defaults for later visits to that repo
+- **FR-012**: Invalid or unsupported saved or authored layout identifiers MUST fall back to `fCoSE` without blocking graph browsing
+- **FR-013**: The currently active layout MUST be clearly visible in the viewer controls
+- **FR-014**: Layout selection and authored default behavior MUST work in both the hosted app and the embeddable lib viewer
+
+### Key Entities
+
+- **Layout Option**: A user-selectable graph arrangement mode such as `fCoSE`, `ELK`, `Cola`, `Dagre`, or `Concentric`
+- **Repo Layout Preference**: The last layout a user explicitly chose for a specific repo
+- **View Layout Default**: An optional authored layout preference attached to a named view so first-time visitors see that view in its intended presentation
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Users can switch among at least five layout options from the viewer controls in a single browsing session
+- **SC-002**: In manual verification on graph-browser’s self graph and at least one downstream repo, switching layouts preserves the active browsing context in 100% of tested flows
+- **SC-003**: Returning to a previously visited repo restores the user’s last explicit layout choice in 100% of tested cases
+- **SC-004**: A view with an authored default layout opens in that layout for first-time visitors in 100% of tested cases
+- **SC-005**: Invalid or unsupported saved/authored layout identifiers never prevent the graph from rendering; the viewer falls back to `fCoSE` in 100% of tested cases
+
+## Assumptions
+
+- Layout changes apply to whatever graph the user is currently viewing, whether that is the full graph, a query result, or a legacy view
+- Layout preferences are stored per repo, not separately per view
+- Query-backed views and legacy view files both remain supported during this feature
+- The hosted app and lib viewer continue to expose the same graph-level controls unless a host intentionally hides outer chrome outside the scope of this feature

--- a/specs/012-layout-picker/tasks.md
+++ b/specs/012-layout-picker/tasks.md
@@ -1,0 +1,89 @@
+# Tasks: User-Selectable Graph Layouts
+
+**Input**: Design documents from `/specs/012-layout-picker/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel with other `[P]` tasks in the same phase
+- **[Story]**: `US1`, `US2`, `US3`
+
+---
+
+## Phase 1: Foundation
+
+- [ ] T001 [P] Update `package.json`, `package-lock.json`, and `src/bootstrap.js` to add and register the additional Cytoscape layout engines needed for `ELK`, `Cola`, and `Dagre`. Keep `Concentric` on the built-in Cytoscape path.
+
+- [ ] T002 Update `src/FFI/Cytoscape.purs` and `src/FFI/Cytoscape.js` to replace the hardcoded `fcose` execution path with layout-aware render/relayout helpers that accept a canonical layout id and preserve the current graph instance.
+
+- [ ] T003 [P] Extend `src/Graph/Query.purs`, `src/Graph/Views.purs`, `schema/query-catalog.schema.json`, and `schema/view.schema.json` with an optional `layout` field for view-like artifacts.
+
+- [ ] T004 Add dedicated layout preference persistence to `src/Persist.purs` using a separate `graph-browser:layout:<identity>` key derived from viewer identity without changing the existing title-keyed node/depth/tutorial restore contract.
+
+- [ ] T005 Add layout state and actions to `src/Viewer/Types.purs`, including the active layout, layout source, and the action used when the user explicitly changes layout.
+
+**Checkpoint**: Layout ids, FFI support, authored metadata, and persistence primitives exist. Story work can now proceed.
+
+---
+
+## Phase 2: User Story 1 - Switch layout to match the graph shape (Priority: P1) 🎯 MVP
+
+**Goal**: Users can switch layouts from the viewer controls and relayout the current graph without losing their place.
+
+**Independent Test**: Load a graph, switch among `fCoSE`, `ELK`, `Cola`, `Dagre`, and `Concentric`, and verify that the current visible graph reflows in place while node/edge/query/tutorial context remains active.
+
+- [ ] T006 [US1] Update `src/Viewer/Controls.purs` to render a visible layout selector in the existing graph control area and show the currently active layout.
+
+- [ ] T007 [US1] Update `src/Viewer.purs` to handle explicit layout-change actions by rerunning the active Cytoscape graph through the selected layout without refetching data.
+
+- [ ] T008 [US1] Update `src/Viewer.purs` and, if necessary, `src/FFI/Cytoscape.js` so layout changes preserve node highlight, edge highlight, active query/view state, tutorial step, depth, and source filters.
+
+- [ ] T009 [US1] Run manual verification for the MVP path on the graph-browser self graph: switch layouts with a selected node, selected edge, active query, and active tutorial step.
+
+**Checkpoint**: Runtime layout switching works and is independently demoable.
+
+---
+
+## Phase 3: User Story 2 - Curated views open with an authored layout default (Priority: P2)
+
+**Goal**: Query-backed and legacy views can declare a preferred default layout for first-time visitors.
+
+**Independent Test**: Configure one query-backed view and one legacy view with different layout defaults, then verify that each view opens in its declared layout when no saved explicit repo preference exists.
+
+- [ ] T010 [US2] Update `src/Viewer.purs` so selecting a legacy view applies that view’s authored default layout when no saved explicit repo preference exists, and falls back to `fcose` on invalid ids.
+
+- [ ] T011 [US2] Update `src/Viewer.purs` so selecting a query-backed view applies the query entry’s authored default layout when the query is tagged as a view and no saved explicit repo preference exists.
+
+- [ ] T012 [US2] Verify that authored defaults are derived behavior only: they affect first-time or unsaved sessions, but do not overwrite an explicit user choice once one exists for the repo.
+
+**Checkpoint**: Curated view defaults work for both authoring models without breaking non-view queries.
+
+---
+
+## Phase 4: User Story 3 - Each repo remembers the user's preferred layout (Priority: P3)
+
+**Goal**: The viewer restores the last explicit layout choice separately for each repo.
+
+**Independent Test**: Choose different layouts in two repos, reload or switch between them, and verify that each repo restores its own explicit layout.
+
+- [ ] T013 [US3] Update `src/Viewer.purs` initialization to restore the saved explicit layout preference from `src/Persist.purs` before applying any authored default layout.
+
+- [ ] T014 [US3] Persist explicit layout changes from `src/Viewer.purs` using the repo/viewer identity derived from parsed `owner/repo` when `dataUrls.baseUrl` is a raw GitHub repo URL, then `dataUrls.baseUrl`, then `config.sourceUrl`, then `config.title`.
+
+- [ ] T015 [US3] Verify repo-scoped behavior in the hosted app flow by loading at least two repos and confirming that saved explicit layouts do not leak across repo identities.
+
+**Checkpoint**: Explicit layout preferences are restored per repo and take precedence over authored defaults.
+
+---
+
+## Phase 5: Polish & Verification
+
+- [ ] T016 [P] Review `README.md` for any user-facing layout authoring or supported-layout documentation that now needs updating.
+
+- [ ] T017 Run `nix develop -c just test`.
+
+- [ ] T018 Run `nix develop -c just bundle-app`.
+
+- [ ] T019 Run `nix develop -c just bundle-lib`.
+
+- [ ] T020 Run the full manual verification flow from `specs/012-layout-picker/quickstart.md`, including invalid-layout fallback cases.

--- a/src/FFI/Cytoscape.js
+++ b/src/FFI/Cytoscape.js
@@ -2,6 +2,7 @@
 // script (dist/bootstrap.js) before this module runs.
 // They register themselves as globals.
 var _cy = null;
+var _activeLayout = "fcose";
 
 function hexToRgba(hex, alpha) {
   var r = parseInt(hex.slice(1, 3), 16);
@@ -134,27 +135,108 @@ function baseStyle(kinds) {
   ];
 }
 
-function runLayout(callback) {
-  if (!_cy) return;
+function normaliseLayoutName(name) {
+  switch ((name || "").toLowerCase()) {
+    case "elk":
+      return "elk";
+    case "cola":
+      return "cola";
+    case "dagre":
+      return "dagre";
+    case "concentric":
+      return "concentric";
+    case "fcose":
+    default:
+      return "fcose";
+  }
+}
+
+function hashString(input) {
+  var s = String(input || "");
+  var h = 0;
+  for (var i = 0; i < s.length; i++) {
+    h = (h * 31 + s.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+function layoutOptions(name, stop) {
   // Suppress edge warnings during layout by temporarily muting console.warn
-  var origWarn = console.warn;
-  console.warn = function (msg) {
-    if (typeof msg === "string" && msg.indexOf("invalid endpoints") !== -1)
-      return;
-    if (
-      typeof msg === "string" &&
-      msg.indexOf("custom wheel sensitivity") !== -1
-    )
-      return;
-    origWarn.apply(console, arguments);
-  };
   var n = _cy.nodes().length;
   var edgeLen = n <= 8 ? 400 : n <= 20 ? 300 : n <= 40 ? 220 : 160;
   var repulsion = n <= 8 ? 80000 : n <= 20 ? 40000 : n <= 40 ? 15000 : 8000;
   var sep = n <= 8 ? 300 : n <= 20 ? 220 : n <= 40 ? 150 : 100;
   var grav = n <= 20 ? 0.04 : n <= 40 ? 0.06 : 0.1;
-  _cy
-    .layout({
+  switch (normaliseLayoutName(name)) {
+    case "elk":
+      return {
+        name: "elk",
+        animate: true,
+        animationDuration: 500,
+        fit: true,
+        padding: 60,
+        nodeDimensionsIncludeLabels: true,
+        elk: {
+          algorithm: "layered",
+          "elk.direction": "RIGHT",
+          "elk.spacing.nodeNode": String(sep),
+          "elk.layered.spacing.nodeNodeBetweenLayers": String(
+            Math.max(80, Math.round(edgeLen * 0.7)),
+          ),
+        },
+        stop: stop,
+      };
+    case "cola":
+      return {
+        name: "cola",
+        animate: true,
+        maxSimulationTime: 1500,
+        fit: true,
+        padding: 60,
+        nodeDimensionsIncludeLabels: true,
+        randomize: true,
+        avoidOverlap: true,
+        handleDisconnected: true,
+        edgeLength: edgeLen,
+        nodeSpacing: function () {
+          return Math.max(20, Math.round(sep * 0.25));
+        },
+        stop: stop,
+      };
+    case "dagre":
+      return {
+        name: "dagre",
+        animate: true,
+        animationDuration: 500,
+        fit: true,
+        padding: 60,
+        nodeDimensionsIncludeLabels: true,
+        rankDir: "LR",
+        rankSep: Math.max(80, sep),
+        nodeSep: Math.max(30, Math.round(sep * 0.35)),
+        edgeSep: Math.max(20, Math.round(sep * 0.2)),
+        stop: stop,
+      };
+    case "concentric":
+      return {
+        name: "concentric",
+        animate: true,
+        animationDuration: 500,
+        fit: true,
+        padding: 60,
+        avoidOverlap: true,
+        minNodeSpacing: Math.max(20, Math.round(sep * 0.2)),
+        concentric: function (node) {
+          return hashString(node.data("nodeGroup") || node.data("kind") || "");
+        },
+        levelWidth: function () {
+          return 1;
+        },
+        stop: stop,
+      };
+    case "fcose":
+    default:
+      return {
       name: "fcose",
       quality: "proof",
       randomize: true,
@@ -170,12 +252,31 @@ function runLayout(callback) {
       gravityRange: 1.5,
       numIter: 20000,
       nodeDimensionsIncludeLabels: true,
-      stop: function () {
-        // Restore console.warn
+      stop: stop,
+    };
+  }
+}
+
+function runLayout(callback) {
+  if (!_cy) return;
+  var origWarn = console.warn;
+  console.warn = function (msg) {
+    if (typeof msg === "string" && msg.indexOf("invalid endpoints") !== -1)
+      return;
+    if (
+      typeof msg === "string" &&
+      msg.indexOf("custom wheel sensitivity") !== -1
+    )
+      return;
+    origWarn.apply(console, arguments);
+  };
+  _cy
+    .layout(
+      layoutOptions(_activeLayout, function () {
         console.warn = origWarn;
         if (callback) callback();
-      },
-    })
+      }),
+    )
     .run();
 }
 
@@ -221,20 +322,28 @@ export const initCytoscape = (containerId) => (kinds) => () => {
   }
 };
 
-export const setElements = (elements) => () => {
+export const setElements = (layoutName) => (elements) => () => {
   if (!_cy) return;
+  _activeLayout = normaliseLayoutName(layoutName);
   _cy.elements().remove();
   _cy.add(elements);
   runLayout();
 };
 
-export const setFocusElements = (elements) => () => {
+export const setFocusElements = (layoutName) => (elements) => () => {
   if (!_cy) return;
+  _activeLayout = normaliseLayoutName(layoutName);
   _cy.elements().remove();
   _cy.add(elements);
   runLayout();
   _cy.edges().style("text-opacity", 1);
   _cy.edges().style("opacity", 1);
+};
+
+export const setLayout = (layoutName) => () => {
+  if (!_cy) return;
+  _activeLayout = normaliseLayoutName(layoutName);
+  runLayout();
 };
 
 export const onNodeTap = (callback) => () => {

--- a/src/FFI/Cytoscape.purs
+++ b/src/FFI/Cytoscape.purs
@@ -4,6 +4,7 @@ module FFI.Cytoscape
   ( initCytoscape
   , setElements
   , setFocusElements
+  , setLayout
   , onNodeTap
   , onNodeHover
   , onEdgeHover
@@ -32,12 +33,16 @@ foreign import initCytoscape
 
 -- | Replace all elements and re-run layout.
 foreign import setElements
-  :: Foreign -> Effect Unit
+  :: String -> Foreign -> Effect Unit
 
 -- | Replace elements for focus mode.
 -- | All edge labels visible.
 foreign import setFocusElements
-  :: Foreign -> Effect Unit
+  :: String -> Foreign -> Effect Unit
+
+-- | Re-run layout on the existing elements.
+foreign import setLayout
+  :: String -> Effect Unit
 
 -- | Register a tap callback on nodes.
 foreign import onNodeTap

--- a/src/Graph/Query.purs
+++ b/src/Graph/Query.purs
@@ -18,6 +18,7 @@ import Data.Argonaut.Decode.Error
 import Data.Either (Either(..))
 import Data.Maybe (Maybe, fromMaybe)
 import Data.Traversable (traverse)
+import Layout (LayoutId, parseLayoutId)
 
 -- | A parameter slot in a SPARQL query template.
 type Parameter =
@@ -35,6 +36,7 @@ type NamedQuery =
   , sparql :: String
   , parameters :: Array Parameter
   , tags :: Array String
+  , layout :: Maybe LayoutId
   }
 
 -- | The full query catalog.
@@ -56,7 +58,9 @@ decodeNamedQuery json = do
   rawParams <- lmap' $ fromMaybe [] <$> obj .:? "parameters"
   parameters <- traverse decodeParameter rawParams
   tags <- lmap' $ fromMaybe [] <$> obj .:? "tags"
-  pure { id, name, description, sparql, parameters, tags }
+  rawLayout <- lmap' $ obj .:? "layout"
+  let layout = rawLayout >>= parseLayoutId
+  pure { id, name, description, sparql, parameters, tags, layout }
 
 decodeParameter :: Json -> Either String Parameter
 decodeParameter json = do

--- a/src/Graph/Views.purs
+++ b/src/Graph/Views.purs
@@ -24,6 +24,7 @@ import Data.Set as Set
 import Data.Traversable (traverse)
 import Graph.Build (buildGraph)
 import Graph.Types (Edge, Graph, Node)
+import Layout (LayoutId, parseLayoutId)
 import Tutorial (Tutorial, decodeTutorial)
 
 -- | An edge reference: source, target, label.
@@ -37,6 +38,7 @@ type EdgeTriple =
 type View =
   { name :: String
   , description :: String
+  , layout :: Maybe LayoutId
   , edges :: Array EdgeTriple
   , tours :: Array Tutorial
   }
@@ -85,11 +87,13 @@ decodeView json = do
   obj <- lmap' $ decodeJson json
   name <- lmap' $ obj .: "name"
   description <- lmap' $ obj .: "description"
+  rawLayout <- lmap' $ obj .:? "layout"
   rawEdges <- lmap' $ obj .: "edges"
   edges <- traverse decodeTriple rawEdges
   rawTours <- lmap' $ fromMaybe [] <$> obj .:? "tours"
   tours <- traverse decodeTutorial rawTours
-  pure { name, description, edges, tours }
+  let layout = rawLayout >>= parseLayoutId
+  pure { name, description, layout, edges, tours }
 
 decodeTriple :: Json -> Either String EdgeTriple
 decodeTriple json = do

--- a/src/Layout.purs
+++ b/src/Layout.purs
@@ -1,0 +1,81 @@
+module Layout
+  ( LayoutId(..)
+  , LayoutSource(..)
+  , allLayouts
+  , defaultLayout
+  , layoutIdToString
+  , layoutLabel
+  , parseLayoutId
+  ) where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Data.String as String
+
+data LayoutId
+  = Fcose
+  | Elk
+  | Cola
+  | Dagre
+  | Concentric
+
+derive instance eqLayoutId :: Eq LayoutId
+
+instance showLayoutId :: Show LayoutId where
+  show = case _ of
+    Fcose -> "Fcose"
+    Elk -> "Elk"
+    Cola -> "Cola"
+    Dagre -> "Dagre"
+    Concentric -> "Concentric"
+
+data LayoutSource
+  = SavedExplicit
+  | ViewDefault
+  | Fallback
+
+derive instance eqLayoutSource :: Eq LayoutSource
+
+instance showLayoutSource :: Show LayoutSource where
+  show = case _ of
+    SavedExplicit -> "SavedExplicit"
+    ViewDefault -> "ViewDefault"
+    Fallback -> "Fallback"
+
+allLayouts :: Array LayoutId
+allLayouts =
+  [ Fcose
+  , Elk
+  , Cola
+  , Dagre
+  , Concentric
+  ]
+
+defaultLayout :: LayoutId
+defaultLayout = Fcose
+
+layoutIdToString :: LayoutId -> String
+layoutIdToString = case _ of
+  Fcose -> "fcose"
+  Elk -> "elk"
+  Cola -> "cola"
+  Dagre -> "dagre"
+  Concentric -> "concentric"
+
+layoutLabel :: LayoutId -> String
+layoutLabel = case _ of
+  Fcose -> "fCoSE"
+  Elk -> "ELK"
+  Cola -> "Cola"
+  Dagre -> "Dagre"
+  Concentric -> "Concentric"
+
+parseLayoutId :: String -> Maybe LayoutId
+parseLayoutId raw = case String.toLower raw of
+  "fcose" -> Just Fcose
+  "elk" -> Just Elk
+  "cola" -> Just Cola
+  "dagre" -> Just Dagre
+  "concentric" -> Just Concentric
+  _ -> Nothing

--- a/src/Persist.purs
+++ b/src/Persist.purs
@@ -5,6 +5,8 @@ module Persist
   ( PersistedState
   , save
   , restore
+  , saveLayoutPreference
+  , loadLayoutPreference
   , RepoListEntry
   , saveRepoList
   , loadRepoList
@@ -25,8 +27,9 @@ import Data.Argonaut.Encode.Class (encodeJson)
 import Data.Argonaut.Parser (jsonParser)
 import Data.Array as Array
 import Data.Either (hush)
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (Maybe, fromMaybe)
 import Effect (Effect)
+import Layout (LayoutId, layoutIdToString, parseLayoutId)
 import Web.HTML as Web.HTML
 import Web.HTML.Window as Window
 import Web.Storage.Storage as Storage
@@ -49,6 +52,9 @@ storageKey title = "graph-browser:" <> title
 
 repoListKey :: String
 repoListKey = "graph-browser:repos"
+
+layoutKey :: String -> String
+layoutKey identity = "graph-browser:layout:" <> identity
 
 save :: String -> PersistedState -> Effect Unit
 save title st = do
@@ -78,6 +84,25 @@ restore title = do
     tutorialId <- hush (obj .:? "tutorialId")
     tutorialStep <- hush (obj .:? "tutorialStep")
     pure { selectedNodeId, depth, tutorialId, tutorialStep }
+
+saveLayoutPreference :: String -> LayoutId -> Effect Unit
+saveLayoutPreference identity layout = do
+  w <- Web.HTML.window
+  storage <- Window.localStorage w
+  let json = encodeJson { layout: layoutIdToString layout }
+  Storage.setItem (layoutKey identity) (stringify json) storage
+
+loadLayoutPreference :: String -> Effect (Maybe LayoutId)
+loadLayoutPreference identity = do
+  w <- Web.HTML.window
+  storage <- Window.localStorage w
+  mRaw <- Storage.getItem (layoutKey identity) storage
+  pure do
+    raw <- mRaw
+    json <- hush (jsonParser raw)
+    obj <- hush (decodeJson json)
+    rawLayout <- hush (obj .:? "layout")
+    rawLayout >>= parseLayoutId
 
 saveRepoList :: Array RepoListEntry -> Effect Unit
 saveRepoList repos = do
@@ -117,6 +142,7 @@ deleteRepo repoId = do
   w <- Web.HTML.window
   storage <- Window.localStorage w
   Storage.removeItem (storageKey repoId) storage
+  Storage.removeItem (layoutKey repoId) storage
   Storage.removeItem (tokenKey repoId) storage
   repos <- loadRepoList
   let filtered = Array.filter (\r -> r.id /= repoId) repos

--- a/src/PromptBuilder.purs
+++ b/src/PromptBuilder.purs
@@ -183,7 +183,10 @@ queryCatalogSchemaBlock =
     <> "- `parameters`: optional `[{name, label, type, default}]`"
     <> " — type: `string` | `node` | `kind`\n"
     <> "- `tags`: optional — `\"view\"` for views,"
-    <> " `\"tour:tour-id\"` for tour stops\n\n"
+    <> " `\"tour:tour-id\"` for tour stops\n"
+    <> "- `layout`: optional — one of `fcose`, `elk`, `cola`,"
+    <> " `dagre`, `concentric`; use it to set a default layout"
+    <> " for `\"view\"` queries\n\n"
     <> "Schema: "
     <> schemaBase
     <> "query-catalog.schema.json"
@@ -451,6 +454,7 @@ filePathsBlock config =
             <>
               [ "- Config: `data/config.json`"
               , "- Query catalog: `data/queries.json`"
+              , "- Views: `data/views/`"
               , "- Tutorials: `data/tutorials/`"
               ]
         )
@@ -470,7 +474,9 @@ prSection config
   | isRdf config = section "How to Submit Changes"
       ( "Fork " <> config.sourceUrl
           <> ". For graph data, edit the RDF source file(s) listed above. "
-          <> "For queries, edit `data/queries.json`. "
+          <> "For queries, edit `data/queries.json`"
+          <> " and set optional `layout` defaults on view queries when useful. "
+          <> "For view JSON files, edit `data/views/`. "
           <> "For tours, add/edit in `data/tutorials/`. "
           <> "Validate against schemas and open a PR."
       )

--- a/src/Viewer.purs
+++ b/src/Viewer.purs
@@ -8,6 +8,7 @@ import Data.Foldable (foldl, for_)
 import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.Set as Set
+import Data.String as String
 import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Web.HTML as Web.HTML
@@ -19,14 +20,18 @@ import Effect.Class (liftEffect)
 import FFI.Cytoscape as Cy
 import FFI.Theme as Theme
 import FFI.Url as Url
-import Fetch (Method(..), fetch)
 import Graph.Cytoscape as GCy
 import Graph.Operations (filterBySources, neighborhood, subgraph)
 import Foreign (Foreign, unsafeToForeign)
 import Foreign.Object as FO
 import Graph.Search (SearchResult(..), search)
+import Layout
+  ( LayoutId
+  , LayoutSource(..)
+  , defaultLayout
+  , layoutIdToString
+  )
 import Persist as Persist
-import Tutorial (Tutorial)
 import Graph.Types
   ( Config
   , Graph
@@ -47,8 +52,6 @@ import PromptBuilder as PB
 import FFI.Oxigraph as Oxigraph
 import Viewer.Types
   ( DataUrls
-  , EdgeInfo
-  , TutorialEntry
   , PromptMode(..)
   , State
   , Action(..)
@@ -60,7 +63,6 @@ import Viewer.Helpers
   , kindColor
   , shouldRenderOntologyReference
   )
-import Viewer.Detail (renderEdgeDetail, renderNodeDetail)
 import Viewer.Tooltip (renderHoverTooltip)
 import Viewer.Controls (renderControls, renderLegend, renderGraphContext)
 import Viewer.Tutorial (currentStop)
@@ -122,6 +124,8 @@ viewer = H.mkComponent
       , paramOptions: Map.empty
       , loadedTutorials: []
       , panelTab: QueriesTab
+      , activeLayout: defaultLayout
+      , layoutSource: Fallback
       , hiddenSources: Set.empty
       , showSourcesPanel: false
       }
@@ -240,6 +244,16 @@ handleAction = case _ of
       Right cfg -> do
         H.modify_ _ { config = cfg }
         liftEffect $ setDocTitle cfg.title
+    stateWithConfig <- H.get
+    savedLayout <- liftEffect $ Persist.loadLayoutPreference
+      (viewerIdentity stateWithConfig)
+    case savedLayout of
+      Just layout ->
+        H.modify_ _
+          { activeLayout = layout
+          , layoutSource = SavedExplicit
+          }
+      Nothing -> pure unit
     state <- H.get
     let
       graphLocations = graphSourceLocations urls state.config
@@ -515,16 +529,38 @@ handleAction = case _ of
     liftEffect $ Url.setThemeParam nextTheme
     H.modify_ _ { theme = nextTheme }
 
+  SetLayout layout -> do
+    state <- H.get
+    H.modify_ _
+      { activeLayout = layout
+      , layoutSource = SavedExplicit
+      }
+    liftEffect $ Persist.saveLayoutPreference
+      (viewerIdentity state)
+      layout
+    liftEffect $ Cy.setLayout
+      (layoutIdToString layout)
+
   ToggleTutorialMenu ->
     H.modify_ \s -> s
       { showTutorialMenu = not s.showTutorialMenu }
 
   StartTutorial file -> do
     state <- H.get
+    let
+      nextLayoutState = case state.activeView of
+        Just view ->
+          derivedLayoutState state view.layout
+        Nothing ->
+          derivedLayoutState state Nothing
     -- Restore full graph when exiting a query to start a tour
     H.modify_ _
       { graph = state.fullGraph
       , activeQuery = Nothing
+      , activeLayout =
+          nextLayoutState.activeLayout
+      , layoutSource =
+          nextLayoutState.layoutSource
       }
     case state.activeView of
       Just view -> do
@@ -699,6 +735,9 @@ handleAction = case _ of
           filtered = Views.filterByView view
             state.fullGraph
           start = mostConnectedNode filtered
+          nextLayoutState = derivedLayoutState
+            state
+            view.layout
           tours = map
             ( \t ->
                 { id: t.id
@@ -719,6 +758,10 @@ handleAction = case _ of
           , showViewPicker = false
           , hoveredEdge = Nothing
           , hoveredNode = Nothing
+          , activeLayout =
+              nextLayoutState.activeLayout
+          , layoutSource =
+              nextLayoutState.layoutSource
           }
         renderGraph
 
@@ -734,6 +777,9 @@ handleAction = case _ of
       globalTours = case idxResult of
         Left _ -> []
         Right idx -> idx
+      nextLayoutState = derivedLayoutState
+        state
+        Nothing
     H.modify_ _
       { graph = state.fullGraph
       , activeView = Nothing
@@ -745,6 +791,10 @@ handleAction = case _ of
       , showViewPicker = false
       , hoveredEdge = Nothing
       , hoveredNode = Nothing
+      , activeLayout =
+          nextLayoutState.activeLayout
+      , layoutSource =
+          nextLayoutState.layoutSource
       }
     renderGraph
 
@@ -839,6 +889,13 @@ handleAction = case _ of
             let
               filtered = subgraph nodeIds state.fullGraph
               start = mostConnectedNode filtered
+              nextLayoutState =
+                if Array.elem "view" query.tags then
+                  derivedLayoutState state query.layout
+                else
+                  { activeLayout: state.activeLayout
+                  , layoutSource: state.layoutSource
+                  }
             -- Keep the original template in activeQuery
             -- (SelectQuery sets it); only set it for
             -- non-parameterized direct executions.
@@ -854,12 +911,20 @@ handleAction = case _ of
               , showViewPicker = false
               , hoveredEdge = Nothing
               , hoveredNode = Nothing
+              , activeLayout =
+                  nextLayoutState.activeLayout
+              , layoutSource =
+                  nextLayoutState.layoutSource
               }
             renderGraph
 
   ClearQuery -> do
     state <- H.get
-    let start = mostConnectedNode state.fullGraph
+    let
+      start = mostConnectedNode state.fullGraph
+      nextLayoutState = derivedLayoutState
+        state
+        Nothing
     H.modify_ _
       { graph = state.fullGraph
       , activeQuery = Nothing
@@ -870,6 +935,10 @@ handleAction = case _ of
       , hoveredNode = Nothing
       , tutorialActive = false
       , tutorial = Nothing
+      , activeLayout =
+          nextLayoutState.activeLayout
+      , layoutSource =
+          nextLayoutState.layoutSource
       }
     renderGraph
 
@@ -891,9 +960,9 @@ renderGraph = do
     visible = filterBySources state.hiddenSources base
 
   liftEffect $ Cy.setFocusElements
+    (layoutIdToString state.activeLayout)
     (GCy.toElements visible)
-  for_ state.selected \node ->
-    liftEffect $ Cy.markRoot node.id
+  liftEffect $ replaySelectionState state
   persistState
 
 mostConnectedNode :: Graph -> Maybe Node
@@ -956,11 +1025,22 @@ applyTutorialStop = do
                       filtered = subgraph nodeIds
                         state.fullGraph
                       start = mostConnectedNode filtered
+                      nextLayoutState =
+                        if Array.elem "view" query.tags then
+                          derivedLayoutState state query.layout
+                        else
+                          { activeLayout: state.activeLayout
+                          , layoutSource: state.layoutSource
+                          }
                     H.modify_ _
                       { graph = filtered
                       , activeQuery = Just query
                       , selected = start
                       , hoveredEdge = Nothing
+                      , activeLayout =
+                          nextLayoutState.activeLayout
+                      , layoutSource =
+                          nextLayoutState.layoutSource
                       }
                     renderGraph
       Nothing -> do
@@ -1050,3 +1130,53 @@ toggleTheme :: String -> String
 toggleTheme theme =
   if normalizeTheme theme == "light" then "dark"
   else "light"
+
+replaySelectionState :: State -> Effect Unit
+replaySelectionState state = do
+  for_ state.selected \node ->
+    Cy.markRoot node.id
+  for_ state.selectedEdge \edge ->
+    Cy.markEdge edge.sourceId edge.targetId
+
+derivedLayoutState
+  :: State
+  -> Maybe LayoutId
+  -> { activeLayout :: LayoutId, layoutSource :: LayoutSource }
+derivedLayoutState state mLayout
+  | state.layoutSource == SavedExplicit =
+      { activeLayout: state.activeLayout
+      , layoutSource: SavedExplicit
+      }
+  | otherwise = case mLayout of
+      Just layout ->
+        { activeLayout: layout
+        , layoutSource: ViewDefault
+        }
+      Nothing ->
+        { activeLayout: defaultLayout
+        , layoutSource: Fallback
+        }
+
+viewerIdentity :: State -> String
+viewerIdentity state =
+  case repoIdentityFromBaseUrl state.dataUrls.baseUrl of
+    Just repoId -> repoId
+    Nothing | state.config.sourceUrl /= "" ->
+      state.config.sourceUrl
+    Nothing ->
+      state.config.title
+
+repoIdentityFromBaseUrl :: String -> Maybe String
+repoIdentityFromBaseUrl url = do
+  let prefix = "https://raw.githubusercontent.com/"
+  if String.take (String.length prefix) url /= prefix then
+    Nothing
+  else do
+    let
+      parts = Array.filter (_ /= "")
+        ( String.split (String.Pattern "/")
+            (String.drop (String.length prefix) url)
+        )
+    owner <- Array.index parts 0
+    repo <- Array.index parts 1
+    pure (owner <> "/" <> repo)

--- a/src/Viewer/Controls.purs
+++ b/src/Viewer/Controls.purs
@@ -9,6 +9,7 @@ import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
+import Layout (allLayouts, defaultLayout, layoutIdToString, layoutLabel, parseLayoutId)
 import Viewer.Helpers (cls, depthBtn)
 import Viewer.Types (Action(..), State)
 
@@ -64,6 +65,16 @@ renderControls state =
             else HH.text ""
           ]
       else HH.text ""
+    , HH.select
+        [ cls "param-select"
+        , HP.attr (HH.AttrName "style")
+            "width:auto; min-width:132px;"
+        , HE.onValueChange \raw ->
+            case parseLayoutId raw of
+              Just layout -> SetLayout layout
+              Nothing -> SetLayout defaultLayout
+        ]
+        (map mkLayoutOption allLayouts)
     , HH.button
         [ cls "control-btn"
         , HE.onClick \_ -> FitAll
@@ -87,6 +98,14 @@ renderControls state =
             [ HH.text "All" ]
         ]
     ]
+  where
+  mkLayoutOption layout =
+    HH.option
+      [ HP.value (layoutIdToString layout)
+      , HP.selected
+          (state.activeLayout == layout)
+      ]
+      [ HH.text (layoutLabel layout) ]
 
 renderThemeToggle
   :: forall m. State -> H.ComponentHTML Action () m

--- a/src/Viewer/Types.purs
+++ b/src/Viewer/Types.purs
@@ -8,6 +8,7 @@ import Graph.Query as Query
 import Graph.Views as Views
 import FFI.Oxigraph as Oxigraph
 import Graph.Search (SearchResult)
+import Layout (LayoutId, LayoutSource)
 import Tutorial (Tutorial)
 
 -- | Data URLs that the viewer fetches on init.
@@ -80,6 +81,8 @@ type State =
   , paramOptions :: Map.Map String (Array String)
   , loadedTutorials :: Array Tutorial
   , panelTab :: PanelTab
+  , activeLayout :: LayoutId
+  , layoutSource :: LayoutSource
   -- | IRIs of source graphs the user has hidden. Nodes/edges whose
   -- | sources is a non-empty subset of this set are filtered from the
   -- | view. Nodes/edges with empty sources are always visible.
@@ -119,6 +122,7 @@ data Action
   | ClearQuery
   | ToggleQueryCatalog
   | SetParamValue String String
+  | SetLayout LayoutId
   | SetPanelTab PanelTab
   | ToggleSource String
   | ToggleSourcesPanel

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,8 +1,14 @@
 import cytoscape from "cytoscape";
+import cola from "cytoscape-cola";
+import dagre from "cytoscape-dagre";
+import elk from "cytoscape-elk";
 import fcose from "cytoscape-fcose";
 import * as oxigraph from "oxigraph/web.js";
 import wasmBytes from "oxigraph/web_bg.wasm";
 
+cytoscape.use(cola);
+cytoscape.use(dagre);
+cytoscape.use(elk);
 cytoscape.use(fcose);
 window.cytoscape = cytoscape;
 

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -12,6 +12,7 @@ import Test.Spec.Runner (runSpec)
 import Test.QueryCatalog as QueryCatalog
 import Test.Sparql as Sparql
 import Test.SelfGraph as SelfGraph
+import Test.ViewDecode as ViewDecode
 
 main :: Effect Unit
 main = launchAff_ $ runSpec [ consoleReporter ] do
@@ -21,3 +22,4 @@ main = launchAff_ $ runSpec [ consoleReporter ] do
   RdfImport.spec
   Sparql.spec
   SelfGraph.spec
+  ViewDecode.spec

--- a/test/Test/QueryCatalog.purs
+++ b/test/Test/QueryCatalog.purs
@@ -4,7 +4,9 @@ import Prelude
 
 import Data.Argonaut.Parser (jsonParser)
 import Data.Either (Either(..), isLeft)
+import Data.Maybe (Maybe(..))
 import Graph.Query (decodeQueryCatalog)
+import Layout (LayoutId(..))
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldEqual, shouldSatisfy)
 
@@ -26,6 +28,7 @@ spec = describe "Graph.Query.decodeQueryCatalog" do
         (map _.name catalog) `shouldEqual` [ "All Nodes" ]
         (map _.parameters catalog) `shouldEqual` [ [] ]
         (map _.tags catalog) `shouldEqual` [ [] ]
+        (map _.layout catalog) `shouldEqual` [ Nothing ]
 
   it "decodes parameters and tags" do
     let
@@ -47,6 +50,7 @@ spec = describe "Graph.Query.decodeQueryCatalog" do
         let q = catalog
         (map _.tags q) `shouldEqual`
           [ [ "view", "parameterized" ] ]
+        (map _.layout q) `shouldEqual` [ Nothing ]
         case map _.parameters q of
           [ [ p ] ] -> do
             p.name `shouldEqual` "kind"
@@ -59,6 +63,35 @@ spec = describe "Graph.Query.decodeQueryCatalog" do
       Left err -> fail err
       Right catalog ->
         catalog `shouldEqual` []
+
+  it "decodes an optional layout" do
+    let
+      json = """[{
+        "id": "module-flow",
+        "name": "Module Flow",
+        "description": "Flow view",
+        "sparql": "SELECT ?node WHERE { ?node ?p ?o }",
+        "tags": ["view"],
+        "layout": "dagre"
+      }]"""
+    case jsonParser json >>= decodeQueryCatalog of
+      Left err -> fail err
+      Right catalog ->
+        (map _.layout catalog) `shouldEqual` [ Just Dagre ]
+
+  it "ignores an invalid layout value" do
+    let
+      json = """[{
+        "id": "broken-layout",
+        "name": "Broken Layout",
+        "description": "Still decodes",
+        "sparql": "SELECT ?node WHERE { ?node ?p ?o }",
+        "layout": "unknown-layout"
+      }]"""
+    case jsonParser json >>= decodeQueryCatalog of
+      Left err -> fail err
+      Right catalog ->
+        (map _.layout catalog) `shouldEqual` [ Nothing ]
 
   it "rejects missing required fields" do
     let

--- a/test/Test/ViewDecode.purs
+++ b/test/Test/ViewDecode.purs
@@ -1,0 +1,45 @@
+module Test.ViewDecode where
+
+import Prelude
+
+import Data.Argonaut.Parser (jsonParser)
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import Graph.Views (decodeView)
+import Layout (LayoutId(..))
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+spec :: Spec Unit
+spec = describe "Graph.Views.decodeView" do
+
+  it "decodes an optional layout" do
+    let
+      json = """{
+        "name": "Architecture Rings",
+        "description": "Grouped by concern",
+        "layout": "concentric",
+        "edges": [["viewer", "query-panel", "contains"]],
+        "tours": []
+      }"""
+    case jsonParser json >>= decodeView of
+      Left err -> fail err
+      Right view ->
+        view.layout `shouldEqual` Just Concentric
+
+  it "ignores an invalid layout value" do
+    let
+      json = """{
+        "name": "Broken Layout",
+        "description": "Falls back",
+        "layout": "nope",
+        "edges": [["viewer", "query-panel", "contains"]],
+        "tours": []
+      }"""
+    case jsonParser json >>= decodeView of
+      Left err -> fail err
+      Right view ->
+        view.layout `shouldEqual` Nothing
+
+  where
+  fail msg = shouldEqual msg ""


### PR DESCRIPTION
## Summary

This PR adds user-selectable graph layouts to the shared viewer and wires the feature through the full stack: viewer state, persistence, query/view metadata, Cytoscape layout engines, schema validation, tests, and docs.

Closes #39.

The feature now supports these layout IDs:

- `fcose`
- `elk`
- `cola`
- `dagre`
- `concentric`

The control is exposed in the viewer toolbar, relayouts the current graph in-session, and persists the user's explicit choice per repo.

## What Changed

### 1. Added an explicit layout model in PureScript

A new `Layout` module defines the canonical layout IDs, labels, parsing, default selection, and the source of the current effective layout (`SavedExplicit`, `ViewDefault`, `Fallback`).

This keeps layout precedence explicit in PureScript instead of burying it in the Cytoscape FFI.

### 2. Extended viewer state and behavior

The viewer now tracks:

- the active layout
- why that layout is active

Behavior changes:

- on initialization, the viewer restores a saved explicit layout preference when present
- when the user picks a layout, the graph relayouts without reloading data
- when a legacy view or a query-backed view becomes active, authored defaults apply only if there is no saved explicit choice
- when clearing a query or jumping between tutorial/query/view flows, the effective layout is recomputed instead of silently drifting
- selection styling is replayed after rerenders so node/edge focus survives layout changes

### 3. Added dedicated layout persistence

This PR deliberately does **not** change the existing title-keyed persistence for selected node, depth, and tutorial progress.

Instead it adds a separate localStorage entry:

- `graph-browser:layout:<identity>`

The identity is derived to stay repo-scoped in app mode:

- parse `owner/repo` from raw GitHub `baseUrl` when possible
- otherwise fall back to `baseUrl`
- otherwise `config.sourceUrl`
- otherwise `config.title`

That keeps explicit layout choices repo-specific without broadening the scope of the older persistence contract.

### 4. Added authored layout defaults to both view mechanisms

Both view entry points now accept an optional `layout` field:

- query-backed views in `data/queries.json`
- legacy view JSON files in `data/views/*.json`

Invalid layout strings are ignored at decode time rather than failing the whole file.

### 5. Added Cytoscape layout engines and runtime switching

The bundle now registers:

- `cytoscape-fcose`
- `cytoscape-elk`
- `cytoscape-cola`
- `cytoscape-dagre`

The FFI keeps one active layout concept and uses it for both fresh renders and direct relayout requests. Each layout gets conservative default options tuned for this viewer so switching is immediate and doesn't require data reload.

### 6. Updated schemas, prompt-builder context, and README

The JSON schemas now validate the optional `layout` field for both query-backed and legacy views.

The prompt-builder guidance and README now document:

- supported layout IDs
- where to author default layouts
- the fact that explicit user choice overrides authored defaults after the first selection

### 7. Added and extended tests

The PR adds decode coverage for both query-backed and legacy view layout metadata, while preserving existing integration tests over the self-graph.

## Design Choices

### Precedence rule

The effective layout order implemented here is:

1. saved explicit repo layout
2. authored default on the active view
3. `fcose` fallback

This matches the spec and keeps authored defaults useful for first-time visitors without overriding a deliberate user choice.

### Separate persistence instead of mutating `PersistedState`

I kept layout preference storage separate from the older selected-node/depth/tutorial restore path. Re-keying the older persistence model would have expanded the risk of this change well beyond the layout feature.

### Canonical repo identity in app mode

The spec work initially described `baseUrl` directly as the primary identity input. During implementation I tightened that to canonical `owner/repo` when `baseUrl` is a raw GitHub URL, so branch previews share the same repo-scoped layout preference instead of fragmenting by branch ref.

The spec artifacts in `specs/012-layout-picker/` were updated to reflect that implementation decision.

## Files to Review

Core implementation:

- `src/Layout.purs`
- `src/Viewer.purs`
- `src/Viewer/Controls.purs`
- `src/Persist.purs`
- `src/FFI/Cytoscape.js`
- `src/bootstrap.js`

Data/model/schema:

- `src/Graph/Query.purs`
- `src/Graph/Views.purs`
- `schema/query-catalog.schema.json`
- `schema/view.schema.json`

Tests and docs:

- `test/Test/QueryCatalog.purs`
- `test/Test/ViewDecode.purs`
- `README.md`
- `specs/012-layout-picker/*`

## Verification

Executed locally:

- `nix develop -c just test`
- `nix develop -c just bundle-app`
- `nix develop -c just bundle-lib`

Results:

- tests passed (`30/30`)
- app bundle succeeded
- lib bundle succeeded

## Follow-up

I did not deploy a preview in this PR because the repo does not define a concrete `surge` task or checked-in preview workflow. If we want a Surge preview here, that should be added as an explicit, repeatable command rather than inferred ad hoc.

