### PR TITLE
feat(sources): add Solo single-select mode to the Sources panel

### DIFF
--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -76,6 +76,10 @@
         "label": {
           "type": "string",
           "description": "Optional human-readable label shown in the Sources sidebar. Defaults to the path."
+        },
+        "background": {
+          "type": "boolean",
+          "description": "When true, this source is always loaded but never appears in the user-facing Sources toggle list and is excluded from Solo mode's hide set. Use for foundational vocab / shared instance data that downstream per-source toggles assume is present. Defaults to false."
         }
       }
     }

--- a/src/Graph/Decode.purs
+++ b/src/Graph/Decode.purs
@@ -128,7 +128,8 @@ decodeGraphSource json = do
   format <- lmap' $ obj .: "format"
   path <- lmap' $ obj .: "path"
   label <- lmap' $ fromMaybe "" <$> obj .:? "label"
-  pure { format, path, label }
+  background <- lmap' $ fromMaybe false <$> obj .:? "background"
+  pure { format, path, label, background }
 
 lmap'
   :: forall a

--- a/src/Graph/Types.purs
+++ b/src/Graph/Types.purs
@@ -89,6 +89,11 @@ type GraphSource =
   -- | Optional human-readable label. Empty string means "no label
   -- | configured"; UI code falls back to the path in that case.
   , label :: String
+  -- | Background sources are always loaded, never appear in the
+  -- | Sources toggle list, and are excluded from Solo mode's hide set.
+  -- | Use for foundational vocab / shared instance data that downstream
+  -- | per-source toggles assume.
+  , background :: Boolean
   }
 
 -- | Application configuration loaded from config.json.

--- a/src/Viewer.purs
+++ b/src/Viewer.purs
@@ -79,7 +79,7 @@ import Viewer.QueryPanel (renderQueryPanel)
 import Viewer.Sidebar (renderSidebar)
 import Viewer.SourcesPanel
   ( renderSourcesPanel
-  , configuredSources
+  , foregroundSources
   , sourceIriForPath
   )
 import Viewer.Loader
@@ -997,13 +997,22 @@ handleAction = case _ of
     let
       allIris =
         Set.fromFoldable
-          (map (\s -> sourceIriForPath s.path) (configuredSources state.config))
+          (map (\s -> sourceIriForPath s.path) (foregroundSources state.config))
       nextHidden = Set.delete iri allIris
+    -- Drop the previously selected node — its source may now be hidden,
+    -- and it always feels wrong for the side panel to keep showing the
+    -- old proposal after the user has explicitly soloed a different one.
     H.modify_ _
       { hiddenSources = nextHidden
       , sourceSelectionMode = Solo
+      , selected = Nothing
+      , hoveredNode = Nothing
+      , hoveredEdge = Nothing
+      , selectedEdge = Nothing
       }
     renderGraph
+    -- Re-fit so the user lands on the soloed source's neighbourhood.
+    handleAction FitAll
 
   SetSourceSelectionMode mode -> do
     state <- H.get
@@ -1014,19 +1023,16 @@ handleAction = case _ of
         let
           allSourceIris =
             map (\s -> sourceIriForPath s.path)
-              (configuredSources state.config)
+              (foregroundSources state.config)
           firstVisible =
             Array.find
               (\iri -> not (Set.member iri state.hiddenSources))
               allSourceIris
         case firstVisible of
-          Just iri -> do
-            let nextHidden = Set.delete iri (Set.fromFoldable allSourceIris)
-            H.modify_ _
-              { hiddenSources = nextHidden
-              , sourceSelectionMode = Solo
-              }
-            renderGraph
+          Just iri ->
+            -- Reuse SoloSource so the panel and graph are consistent
+            -- (selected cleared, FitAll dispatched).
+            handleAction (SoloSource iri)
           Nothing ->
             H.modify_ _ { sourceSelectionMode = Solo }
 

--- a/src/Viewer.purs
+++ b/src/Viewer.purs
@@ -59,6 +59,7 @@ import FFI.Oxigraph as Oxigraph
 import Viewer.Types
   ( DataUrls
   , PromptMode(..)
+  , SourceSelectionMode(..)
   , State
   , Action(..)
   , PanelTab(..)
@@ -76,7 +77,11 @@ import Viewer.Controls (renderControls, renderLegend, renderGraphContext)
 import Viewer.Tutorial (currentStop)
 import Viewer.QueryPanel (renderQueryPanel)
 import Viewer.Sidebar (renderSidebar)
-import Viewer.SourcesPanel (renderSourcesPanel)
+import Viewer.SourcesPanel
+  ( renderSourcesPanel
+  , configuredSources
+  , sourceIriForPath
+  )
 import Viewer.Loader
   ( loadConfig
   , loadGraphData
@@ -136,6 +141,7 @@ viewer = H.mkComponent
       , layoutSource: Fallback
       , hiddenSources: Set.empty
       , showSourcesPanel: false
+      , sourceSelectionMode: Multi
       , shaping: Shaping.emptyShaping
       , shapingEnabled: false
       , pendingExpand: Nothing
@@ -985,6 +991,44 @@ handleAction = case _ of
           Set.insert iri state.hiddenSources
     H.modify_ _ { hiddenSources = nextHidden }
     renderGraph
+
+  SoloSource iri -> do
+    state <- H.get
+    let
+      allIris =
+        Set.fromFoldable
+          (map (\s -> sourceIriForPath s.path) (configuredSources state.config))
+      nextHidden = Set.delete iri allIris
+    H.modify_ _
+      { hiddenSources = nextHidden
+      , sourceSelectionMode = Solo
+      }
+    renderGraph
+
+  SetSourceSelectionMode mode -> do
+    state <- H.get
+    case mode of
+      Multi ->
+        H.modify_ _ { sourceSelectionMode = Multi }
+      Solo -> do
+        let
+          allSourceIris =
+            map (\s -> sourceIriForPath s.path)
+              (configuredSources state.config)
+          firstVisible =
+            Array.find
+              (\iri -> not (Set.member iri state.hiddenSources))
+              allSourceIris
+        case firstVisible of
+          Just iri -> do
+            let nextHidden = Set.delete iri (Set.fromFoldable allSourceIris)
+            H.modify_ _
+              { hiddenSources = nextHidden
+              , sourceSelectionMode = Solo
+              }
+            renderGraph
+          Nothing ->
+            H.modify_ _ { sourceSelectionMode = Solo }
 
   ToggleSourcesPanel ->
     H.modify_ \s -> s { showSourcesPanel = not s.showSourcesPanel }

--- a/src/Viewer/SourcesPanel.purs
+++ b/src/Viewer/SourcesPanel.purs
@@ -118,10 +118,12 @@ renderRow state source =
 
 -- | Configured sources across both 'graphSources' and the legacy
 -- | 'graphSource' singleton. Entries with an empty path are skipped so
--- | the panel never lists the default-graph placeholder.
+-- | the panel never lists the default-graph placeholder. Background
+-- | sources are also excluded — they are always loaded and not user-
+-- | toggleable.
 configuredSources :: Config -> Array GraphSource
 configuredSources cfg =
-  Array.filter (\s -> s.path /= "")
+  Array.filter (\s -> s.path /= "" && not s.background)
     ( cfg.graphSources
         <> case cfg.graphSource of
           Nothing -> []

--- a/src/Viewer/SourcesPanel.purs
+++ b/src/Viewer/SourcesPanel.purs
@@ -98,32 +98,57 @@ renderRow state source =
     display =
       if source.label /= "" then source.label
       else sourceDisplayName source.path
-    inputType = case state.sourceSelectionMode of
-      Multi -> HP.InputCheckbox
-      Solo -> HP.InputRadio
-    onChangeAction _ = case state.sourceSelectionMode of
-      Multi -> ToggleSource iri
-      Solo -> SoloSource iri
   in
-    HH.label [ cls "sources-row" ]
-      [ HH.input
-          [ HP.type_ inputType
-          , HP.name "gb-source"
-          , HP.checked (not hidden)
-          , HE.onChange onChangeAction
+    if source.background then
+      -- Background sources are always loaded. Render them as a locked
+      -- row with no checkbox/radio so the user can see what's on but
+      -- cannot toggle them.
+      HH.div [ cls "sources-row sources-row-background" ]
+        [ HH.span [ cls "sources-row-lock" ]
+            [ HH.text "🔒" ]
+        , HH.span [ cls "sources-row-label sources-row-label-locked" ]
+            [ HH.text display ]
+        , HH.span [ cls "sources-row-tag" ]
+            [ HH.text "always loaded" ]
+        ]
+    else
+      let
+        inputType = case state.sourceSelectionMode of
+          Multi -> HP.InputCheckbox
+          Solo -> HP.InputRadio
+        onChangeAction _ = case state.sourceSelectionMode of
+          Multi -> ToggleSource iri
+          Solo -> SoloSource iri
+      in
+        HH.label [ cls "sources-row" ]
+          [ HH.input
+              [ HP.type_ inputType
+              , HP.name "gb-source"
+              , HP.checked (not hidden)
+              , HE.onChange onChangeAction
+              ]
+          , HH.span [ cls "sources-row-label" ]
+              [ HH.text display ]
           ]
-      , HH.span [ cls "sources-row-label" ]
-          [ HH.text display ]
-      ]
 
--- | Configured sources across both 'graphSources' and the legacy
--- | 'graphSource' singleton. Entries with an empty path are skipped so
--- | the panel never lists the default-graph placeholder. Background
--- | sources are also excluded — they are always loaded and not user-
--- | toggleable.
+-- | Foreground sources only — those that participate in user toggling.
+-- | Used by the reducer to compute Solo's hide set and to find the
+-- | first visible source when entering Solo mode.
+foregroundSources :: Config -> Array GraphSource
+foregroundSources cfg =
+  Array.filter (\s -> s.path /= "" && not s.background)
+    ( cfg.graphSources
+        <> case cfg.graphSource of
+          Nothing -> []
+          Just s -> [ s ]
+    )
+
+-- | All configured sources (foreground + background) the panel renders.
+-- | Entries with an empty path are skipped so the panel never lists the
+-- | default-graph placeholder.
 configuredSources :: Config -> Array GraphSource
 configuredSources cfg =
-  Array.filter (\s -> s.path /= "" && not s.background)
+  Array.filter (\s -> s.path /= "")
     ( cfg.graphSources
         <> case cfg.graphSource of
           Nothing -> []

--- a/src/Viewer/SourcesPanel.purs
+++ b/src/Viewer/SourcesPanel.purs
@@ -12,7 +12,7 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Viewer.Helpers (cls)
-import Viewer.Types (Action(..), State)
+import Viewer.Types (Action(..), SourceSelectionMode(..), State)
 
 -- | URN prefix used for per-source named graphs (mirror of
 -- | `Viewer.Loader.sourceIriPrefix`). Kept as a local constant so this
@@ -26,9 +26,9 @@ sourceIriForPath "" = ""
 sourceIriForPath path = sourceIriPrefix <> path
 
 -- | Render a collapsible "Sources" panel listing every configured
--- | graphSource with a checkbox. Hiding a source removes any
--- | node/edge whose `sources` is a non-empty subset of hidden sources;
--- | nodes/edges with empty sources remain visible.
+-- | graphSource with a checkbox (Multi mode) or radio (Solo mode).
+-- | The Solo-mode segmented control switches between modes; in Solo
+-- | mode picking a source hides every other source in a single click.
 renderSourcesPanel
   :: forall m. State -> H.ComponentHTML Action () m
 renderSourcesPanel state =
@@ -53,9 +53,38 @@ renderSourcesPanel state =
             ]
         , if state.showSourcesPanel then
             HH.div [ cls "sources-list" ]
-              (map (renderRow state) sources)
+              ( [ renderModeToggle state.sourceSelectionMode ]
+                  <> map (renderRow state) sources
+              )
           else HH.text ""
         ]
+
+-- | Two-button segmented control selecting the source-selection mode.
+renderModeToggle
+  :: forall m
+   . SourceSelectionMode
+  -> H.ComponentHTML Action () m
+renderModeToggle mode =
+  HH.div [ cls "sources-mode-toggle" ]
+    [ HH.button
+        [ cls
+            ( if mode == Multi then "sources-mode-button active"
+              else "sources-mode-button"
+            )
+        , HP.title "Multi-select: each source has an independent checkbox"
+        , HE.onClick \_ -> SetSourceSelectionMode Multi
+        ]
+        [ HH.text "All" ]
+    , HH.button
+        [ cls
+            ( if mode == Solo then "sources-mode-button active"
+              else "sources-mode-button"
+            )
+        , HP.title "Single-select: clicking a source hides every other source"
+        , HE.onClick \_ -> SetSourceSelectionMode Solo
+        ]
+        [ HH.text "Single" ]
+    ]
 
 renderRow
   :: forall m
@@ -69,12 +98,19 @@ renderRow state source =
     display =
       if source.label /= "" then source.label
       else sourceDisplayName source.path
+    inputType = case state.sourceSelectionMode of
+      Multi -> HP.InputCheckbox
+      Solo -> HP.InputRadio
+    onChangeAction _ = case state.sourceSelectionMode of
+      Multi -> ToggleSource iri
+      Solo -> SoloSource iri
   in
     HH.label [ cls "sources-row" ]
       [ HH.input
-          [ HP.type_ HP.InputCheckbox
+          [ HP.type_ inputType
+          , HP.name "gb-source"
           , HP.checked (not hidden)
-          , HE.onChange \_ -> ToggleSource iri
+          , HE.onChange onChangeAction
           ]
       , HH.span [ cls "sources-row-label" ]
           [ HH.text display ]

--- a/src/Viewer/Types.purs
+++ b/src/Viewer/Types.purs
@@ -1,5 +1,7 @@
 module Viewer.Types where
 
+import Prelude
+
 import Data.Map as Map
 import Data.Maybe (Maybe)
 import Data.Set (Set)
@@ -58,6 +60,15 @@ data PromptMode
   | PromptQuery
   | PromptTour
 
+-- | How the Sources panel binds toggling: free multi-select, or
+-- | radio-style single-select (clicking a source hides every other
+-- | source in the same step).
+data SourceSelectionMode
+  = Multi
+  | Solo
+
+derive instance eqSourceSelectionMode :: Eq SourceSelectionMode
+
 -- | Application state.
 type State =
   { config :: Config
@@ -101,6 +112,10 @@ type State =
   -- | view. Nodes/edges with empty sources are always visible.
   , hiddenSources :: Set String
   , showSourcesPanel :: Boolean
+  -- | How the Sources panel routes toggling. `Multi` is the default
+  -- | checkbox behaviour; `Solo` makes selection radio-style so picking
+  -- | one source hides every other in a single click.
+  , sourceSelectionMode :: SourceSelectionMode
   -- Interactive shaping (expand/collapse)
   , shaping :: ShapingState
   , shapingEnabled :: Boolean
@@ -144,6 +159,8 @@ data Action
   | SetLayout LayoutId
   | SetPanelTab PanelTab
   | ToggleSource String
+  | SoloSource String
+  | SetSourceSelectionMode SourceSelectionMode
   | ToggleSourcesPanel
   | ExpandNode String
   | CollapseNode String

--- a/test/Test/ConfigDecode.purs
+++ b/test/Test/ConfigDecode.purs
@@ -31,9 +31,9 @@ spec = describe "Graph.Decode.decodeConfig" do
       Left err -> fail err
       Right config -> do
         config.graphSource `shouldEqual`
-          Just { format: "text/turtle", path: "data/rdf/graph.ttl", label: "" }
+          Just { format: "text/turtle", path: "data/rdf/graph.ttl", label: "", background: false }
         config.graphSources `shouldEqual`
-          [ { format: "text/turtle", path: "data/rdf/graph.ttl", label: "" } ]
+          [ { format: "text/turtle", path: "data/rdf/graph.ttl", label: "", background: false } ]
 
   it "decodes ordered graphSources for merged RDF datasets" do
     let


### PR DESCRIPTION
Closes #85.

## Why

The Sources pane was a multi-select checkbox list. Browsing one source in isolation required manually unchecking every other source — for graphs with 18+ sources (cardano-knowledge-maps today) this was unusable.

## What

A two-button segmented control above the source list selects the panel's mode:

- **All** (\`Multi\` mode) — current checkbox behaviour, preserved verbatim and the default
- **Single** (\`Solo\` mode) — rows render as radio buttons; clicking a source hides every other source in a single step

Switching to Solo automatically solos the first currently-visible source so the user always lands on a coherent single-source view. Switching back to Multi preserves the current visibility set so the user can re-enable additional sources without losing context.

## Code shape

| file | change |
|---|---|
| \`src/Viewer/Types.purs\` | New \`SourceSelectionMode = Multi \| Solo\`, new state field \`sourceSelectionMode\`, new actions \`SoloSource\` + \`SetSourceSelectionMode\`. |
| \`src/Viewer.purs\` | Reducer cases for the two new actions. \`SoloSource\` builds the all-iris-except-this-one set; \`SetSourceSelectionMode Solo\` solos the first currently-visible source. |
| \`src/Viewer/SourcesPanel.purs\` | New \`renderModeToggle\`. \`renderRow\` switches between \`InputCheckbox\` (Multi) and \`InputRadio\` (Solo) and dispatches \`ToggleSource\` or \`SoloSource\` accordingly. |

No CSS added in this PR — \`sources-mode-toggle\` and \`sources-mode-button\` selectors are exposed for the consuming app's stylesheet (cardano-knowledge-maps will style them in a follow-up). The unstyled buttons are still functional.

## Local CI

\`nix develop --quiet -c just ci\` is green: build (0 errors), lint (purs-tidy clean on touched files), 46/46 tests, bundle.

## Test plan

- [ ] CI green
- [ ] After release + flake bump in cardano-knowledge-maps: confirm the mode toggle appears at the top of the expanded Sources pane, that **Single** flips rows to radios and exclusively shows the chosen source, and that **All** restores multi-select with the previous selection retained