### PR TITLE
Improve source-selection controls and state clarity

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -319,7 +319,8 @@
     font-weight: 600;
     color: var(--text-muted);
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: 0;
+    flex: 0 0 auto;
   }
   .sources-count {
     font-size: 11px;
@@ -327,6 +328,18 @@
     background: var(--bg-surface);
     padding: 1px 6px;
     border-radius: 10px;
+    white-space: nowrap;
+    flex: 0 0 auto;
+  }
+  .sources-state {
+    min-width: 0;
+    color: var(--text-faint);
+    font-size: 11px;
+    line-height: 1.2;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1 1 auto;
   }
   .sources-chevron {
     margin-left: auto;
@@ -337,6 +350,45 @@
     display: flex;
     flex-direction: column;
     padding: 4px 0;
+  }
+  .sources-mode-toggle,
+  .sources-actions {
+    display: flex;
+    gap: 6px;
+    padding: 8px 12px 4px;
+  }
+  .sources-mode-button,
+  .sources-action-button {
+    min-width: 0;
+    flex: 1;
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    border-radius: 6px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 11px;
+    line-height: 1.25;
+    padding: 6px 8px;
+    transition: all 0.15s ease;
+  }
+  .sources-mode-button:hover,
+  .sources-action-button:hover {
+    background: var(--border);
+    border-color: var(--text-muted);
+  }
+  .sources-mode-button.active {
+    background: var(--accent-bg);
+    border-color: var(--accent);
+    color: var(--accent-bright);
+  }
+  .sources-action-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+  }
+  .sources-action-button:disabled:hover {
+    background: var(--bg-raised);
+    border-color: var(--border);
   }
   .sources-row {
     display: flex;
@@ -354,10 +406,34 @@
     cursor: pointer;
     margin: 0;
   }
+  .sources-row input[type="radio"] {
+    accent-color: var(--accent);
+    cursor: pointer;
+    margin: 0;
+  }
   .sources-row-label {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+  .sources-row-background {
+    cursor: default;
+    color: var(--text-muted);
+  }
+  .sources-row-background:hover { background: transparent; }
+  .sources-row-lock {
+    width: 13px;
+    flex: 0 0 auto;
+    color: var(--text-faint);
+  }
+  .sources-row-label-locked {
+    color: var(--text-muted);
+  }
+  .sources-row-tag {
+    margin-left: auto;
+    color: var(--text-faint);
+    font-size: 10px;
+    white-space: nowrap;
   }
   .query-panel > * {
     direction: ltr;

--- a/specs/013-source-selection-controls/plan.md
+++ b/specs/013-source-selection-controls/plan.md
@@ -6,8 +6,8 @@
 
 ## Status
 
-**Completed**: Issue created and added to Planning. Source panel scope identified.  
-**Current**: Add explicit source-selection state and bulk controls in the existing PureScript/Halogen sources panel.  
+**Completed**: Issue created and added to Planning. Source panel scope identified. Source-selection state, bulk controls, clearer mode labels, and browser verification are complete.
+**Current**: Ready for PR review.
 **Blockers**: None.
 
 ## Technical Context
@@ -38,8 +38,10 @@
 - Use "Select all" and "Clear all" as explicit bulk commands.
 - Keep row checkboxes because they are the most direct representation of source visibility.
 - Show source state in the collapsed header as `N/M visible`.
+- Count and bulk-control only selectable foreground sources. Background sources remain locked and always loaded.
+- Key source rows by source-selection mode so switching from checkboxes to radios remounts inputs with the correct checked state.
 
 ## Risks
 
-- Elements without source metadata remain visible when all configured sources are hidden. This is existing graph filtering behavior and should not be changed in this issue.
+- Elements without source metadata remain visible when all selectable sources are hidden. This is existing graph filtering behavior and should not be changed in this issue.
 - The repository has both app and library bundles; verification must include the bundled viewer path, not only PureScript compilation.

--- a/specs/013-source-selection-controls/plan.md
+++ b/specs/013-source-selection-controls/plan.md
@@ -6,7 +6,7 @@
 
 ## Status
 
-**Completed**: Issue created and added to Planning. Source panel scope identified. Source-selection state, bulk controls, clearer mode labels, and browser verification are complete.
+**Completed**: Issue created and added to Planning. Source panel scope identified. Source-selection state, bulk controls, clearer mode labels, strict partial-source filtering, and browser verification are complete.
 **Current**: Ready for PR review.
 **Blockers**: None.
 
@@ -20,7 +20,7 @@
   - `ToggleSourcesPanel`
   - `SoloSource String`
   - `SetSourceSelectionMode`
-- Filtering is already implemented by `Graph.Operations.filterBySources`.
+- Filtering is implemented by `Graph.Operations.filterBySources` for the full-source view and `Graph.Operations.filterToSources` for partial or isolated source views.
 
 ## Approach
 
@@ -29,7 +29,8 @@
 3. Add bulk action buttons inside the expanded sources panel.
 4. Improve source mode controls with clearer labels and active state.
 5. Handle the new actions in `Viewer.purs` by updating `hiddenSources`, selection mode, selection, and graph render state consistently with existing source toggles.
-6. Verify with `just lint`, `just build`, `just test`, and browser checks against the example graph.
+6. Render partial source selections through an allow-list filter so selected proposal sources provide the visible graph structure and background sources only provide support data needed by selected-source edges.
+7. Verify with `just lint`, `just build`, `just test`, and browser checks against the example graph and the Cardano Budget 2026 graph.
 
 ## UX Decisions
 
@@ -38,10 +39,11 @@
 - Use "Select all" and "Clear all" as explicit bulk commands.
 - Keep row checkboxes because they are the most direct representation of source visibility.
 - Show source state in the collapsed header as `N/M visible`.
-- Count and bulk-control only selectable foreground sources. Background sources remain locked and always loaded.
+- Count and bulk-control only selectable foreground sources. Background sources remain locked support data, not forced-visible graph structure during partial selection.
 - Key source rows by source-selection mode so switching from checkboxes to radios remounts inputs with the correct checked state.
 
 ## Risks
 
-- Elements without source metadata remain visible when all selectable sources are hidden. This is existing graph filtering behavior and should not be changed in this issue.
+- The full-source view still uses the previous hide-list filtering behavior so existing non-source-aware graphs remain compatible.
+- Partial source views use stricter allow-list filtering; missing source provenance on selected-source edges would hide those edges.
 - The repository has both app and library bundles; verification must include the bundled viewer path, not only PureScript compilation.

--- a/specs/013-source-selection-controls/plan.md
+++ b/specs/013-source-selection-controls/plan.md
@@ -1,0 +1,45 @@
+# Implementation Plan: Source Selection Controls
+
+**Branch**: `fix/improve-source-selection-controls-and-state-clarit`  
+**Spec**: `specs/013-source-selection-controls/spec.md`  
+**Issue**: https://github.com/lambdasistemi/graph-browser/issues/87
+
+## Status
+
+**Completed**: Issue created and added to Planning. Source panel scope identified.  
+**Current**: Add explicit source-selection state and bulk controls in the existing PureScript/Halogen sources panel.  
+**Blockers**: None.
+
+## Technical Context
+
+- UI is PureScript/Halogen.
+- Source panel rendering lives in `src/Viewer/SourcesPanel.purs`.
+- Source-selection state lives in `State.hiddenSources`.
+- Existing actions:
+  - `ToggleSource String`
+  - `ToggleSourcesPanel`
+  - `SoloSource String`
+  - `SetSourceSelectionMode`
+- Filtering is already implemented by `Graph.Operations.filterBySources`.
+
+## Approach
+
+1. Extend `Viewer.Types.Action` with bulk source actions.
+2. Render visible/total source count and a plain-language state summary in the sources header.
+3. Add bulk action buttons inside the expanded sources panel.
+4. Improve source mode controls with clearer labels and active state.
+5. Handle the new actions in `Viewer.purs` by updating `hiddenSources`, selection mode, selection, and graph render state consistently with existing source toggles.
+6. Verify with `just lint`, `just build`, `just test`, and browser checks against the example graph.
+
+## UX Decisions
+
+- Use "Combined sources" for multi-source checkbox mode.
+- Use "Isolate one source" for single-source mode.
+- Use "Select all" and "Clear all" as explicit bulk commands.
+- Keep row checkboxes because they are the most direct representation of source visibility.
+- Show source state in the collapsed header as `N/M visible`.
+
+## Risks
+
+- Elements without source metadata remain visible when all configured sources are hidden. This is existing graph filtering behavior and should not be changed in this issue.
+- The repository has both app and library bundles; verification must include the bundled viewer path, not only PureScript compilation.

--- a/specs/013-source-selection-controls/spec.md
+++ b/specs/013-source-selection-controls/spec.md
@@ -1,0 +1,56 @@
+# Feature Specification: Source Selection Controls
+
+**Feature Branch**: `fix/improve-source-selection-controls-and-state-clarit`  
+**Created**: 2026-04-30  
+**Status**: Draft  
+**Issue**: https://github.com/lambdasistemi/graph-browser/issues/87  
+**Input**: User description: "it starts with everything selected and I don't have a button to deselect everything and also the interface is not that clear like what I'm seeing all or single just buttons and there is no state of the interface"
+
+## User Scenarios & Testing
+
+### User Story 1 - Clear or restore source selection quickly (Priority: P1)
+
+A graph reviewer opens a repository with many RDF sources. They need to clear all sources or select all sources with one action instead of toggling every source checkbox manually.
+
+**Independent Test**: Open a multi-source graph, expand the sources panel, click "Clear all", verify every listed source is unchecked and the rendered graph updates. Click "Select all", verify every source is checked and the graph restores.
+
+### User Story 2 - Understand current source-selection state (Priority: P1)
+
+A graph reviewer needs to know whether they are seeing every source, no selected source, or only part of the source set.
+
+**Independent Test**: Toggle sources and verify the header displays the visible/total source count and an understandable state label.
+
+### User Story 3 - Understand multi-source vs single-source behavior (Priority: P2)
+
+A graph reviewer needs labels that explain whether source checkboxes can be combined or whether one source is being isolated.
+
+**Independent Test**: Switch between combined and isolated source modes and verify the active state is visible and the labels describe the behavior.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The sources panel MUST display the number of visible configured sources out of the total configured sources.
+- **FR-002**: The sources panel MUST provide a one-click action to select all configured sources.
+- **FR-003**: The sources panel MUST provide a one-click action to clear all configured sources.
+- **FR-004**: Bulk actions MUST update the graph using the same filtering semantics as individual source checkboxes.
+- **FR-005**: The UI MUST keep existing individual source checkboxes.
+- **FR-006**: The UI MUST keep existing single-source isolation behavior.
+- **FR-007**: Source-selection mode controls MUST use labels that explain the behavior rather than relying on bare "All" or "Single" wording.
+- **FR-008**: The active source-selection mode MUST be visually indicated.
+- **FR-009**: The source state summary MUST remain visible when the sources list is collapsed.
+- **FR-010**: The controls MUST remain usable on narrow screens.
+
+## Edge Cases
+
+- A graph with no configured sources continues to hide the sources panel.
+- Clearing all configured sources may still leave nodes or edges with no source metadata visible; the UI state still refers only to configured sources.
+- If a single source is isolated, clearing all returns to no configured source selected.
+- If every source is manually checked, the state summary reads as all configured sources visible.
+
+## Success Criteria
+
+- **SC-001**: A user can hide every configured source in one click.
+- **SC-002**: A user can restore every configured source in one click.
+- **SC-003**: A user can read the panel header and know how many configured sources are visible.
+- **SC-004**: A user can identify whether the source panel is in combined-source mode or isolated-source mode.

--- a/specs/013-source-selection-controls/spec.md
+++ b/specs/013-source-selection-controls/spec.md
@@ -40,16 +40,17 @@ A graph reviewer needs labels that explain whether source checkboxes can be comb
 - **FR-008**: The active source-selection mode MUST be visually indicated.
 - **FR-009**: The source state summary MUST remain visible when the sources list is collapsed.
 - **FR-010**: The controls MUST remain usable on narrow screens.
-- **FR-011**: Background sources MUST remain visible as locked, always-on sources and MUST NOT be affected by bulk source controls.
+- **FR-011**: Background sources MUST remain visible as locked support-data sources in the panel and MUST NOT be directly affected by bulk source controls.
+- **FR-012**: When fewer than all selectable sources are visible, graph rendering MUST hide background-only and unselected-source-only graph structure while retaining endpoint nodes needed by selected-source edges.
 
 ## Edge Cases
 
 - A graph with no configured sources continues to hide the sources panel.
-- Clearing all selectable sources may still leave nodes or edges with no source metadata visible; the UI state still refers only to selectable sources.
-- Clearing all selectable sources may still leave nodes or edges from background sources or without source metadata visible.
+- Clearing all selectable sources renders an empty focused graph for source-aware datasets.
+- Background sources can still contribute labels, descriptions, or endpoint nodes when selected proposal edges refer to them.
 - If a single source is isolated, clearing all returns to no selectable source selected.
 - If every selectable source is manually checked, the state summary reads as all selectable sources visible.
-  Background sources are reported separately as always on when present.
+  Background sources are reported separately as support sources when present.
 
 ## Success Criteria
 

--- a/specs/013-source-selection-controls/spec.md
+++ b/specs/013-source-selection-controls/spec.md
@@ -30,9 +30,9 @@ A graph reviewer needs labels that explain whether source checkboxes can be comb
 
 ### Functional Requirements
 
-- **FR-001**: The sources panel MUST display the number of visible configured sources out of the total configured sources.
-- **FR-002**: The sources panel MUST provide a one-click action to select all configured sources.
-- **FR-003**: The sources panel MUST provide a one-click action to clear all configured sources.
+- **FR-001**: The sources panel MUST display the number of visible selectable sources out of the total selectable sources.
+- **FR-002**: The sources panel MUST provide a one-click action to select all selectable sources.
+- **FR-003**: The sources panel MUST provide a one-click action to clear all selectable sources.
 - **FR-004**: Bulk actions MUST update the graph using the same filtering semantics as individual source checkboxes.
 - **FR-005**: The UI MUST keep existing individual source checkboxes.
 - **FR-006**: The UI MUST keep existing single-source isolation behavior.
@@ -40,17 +40,20 @@ A graph reviewer needs labels that explain whether source checkboxes can be comb
 - **FR-008**: The active source-selection mode MUST be visually indicated.
 - **FR-009**: The source state summary MUST remain visible when the sources list is collapsed.
 - **FR-010**: The controls MUST remain usable on narrow screens.
+- **FR-011**: Background sources MUST remain visible as locked, always-on sources and MUST NOT be affected by bulk source controls.
 
 ## Edge Cases
 
 - A graph with no configured sources continues to hide the sources panel.
-- Clearing all configured sources may still leave nodes or edges with no source metadata visible; the UI state still refers only to configured sources.
-- If a single source is isolated, clearing all returns to no configured source selected.
-- If every source is manually checked, the state summary reads as all configured sources visible.
+- Clearing all selectable sources may still leave nodes or edges with no source metadata visible; the UI state still refers only to selectable sources.
+- Clearing all selectable sources may still leave nodes or edges from background sources or without source metadata visible.
+- If a single source is isolated, clearing all returns to no selectable source selected.
+- If every selectable source is manually checked, the state summary reads as all selectable sources visible.
+  Background sources are reported separately as always on when present.
 
 ## Success Criteria
 
-- **SC-001**: A user can hide every configured source in one click.
-- **SC-002**: A user can restore every configured source in one click.
-- **SC-003**: A user can read the panel header and know how many configured sources are visible.
+- **SC-001**: A user can hide every selectable source in one click.
+- **SC-002**: A user can restore every selectable source in one click.
+- **SC-003**: A user can read the panel header and know how many selectable sources are visible.
 - **SC-004**: A user can identify whether the source panel is in combined-source mode or isolated-source mode.

--- a/specs/013-source-selection-controls/tasks.md
+++ b/specs/013-source-selection-controls/tasks.md
@@ -6,22 +6,23 @@
 
 ## Phase 1: State And Actions
 
-- [ ] Add source bulk actions to `Viewer.Types.Action`.
-- [ ] Implement select-all and clear-all handling in `Viewer.purs`.
-- [ ] Ensure bulk actions reset stale selected/hovered detail state and rerender the graph.
+- [x] Add source bulk actions to `Viewer.Types.Action`.
+- [x] Implement select-all and clear-all handling in `Viewer.purs`.
+- [x] Ensure bulk actions reset stale selected/hovered detail state and rerender the graph.
 
 ## Phase 2: Source Panel UI
 
-- [ ] Show `visible/total` source state in the sources panel header.
-- [ ] Add "Select all" and "Clear all" buttons in the expanded panel.
-- [ ] Replace ambiguous mode wording with "Combined sources" and "Isolate one source".
-- [ ] Make active source mode visually distinct.
-- [ ] Keep individual source checkbox rows unchanged in behavior.
+- [x] Show `visible/total` source state in the sources panel header.
+- [x] Add "Select all" and "Clear all" buttons in the expanded panel.
+- [x] Replace ambiguous mode wording with "Combined sources" and "Isolate one source".
+- [x] Make active source mode visually distinct.
+- [x] Keep individual source checkbox rows unchanged in behavior.
+- [x] Key source rows by source-selection mode so radio checked state is reliable after mode switches.
 
 ## Phase 3: Verification
 
-- [ ] Run `just lint`.
-- [ ] Run `just build`.
-- [ ] Run `just test`.
-- [ ] Build and serve the bundled app.
-- [ ] Verify with Playwright that clear all, select all, source counts, and active mode state work.
+- [x] Run `just lint`.
+- [x] Run `just build`.
+- [x] Run `just test`.
+- [x] Build and serve the bundled app.
+- [x] Verify with Playwright that clear all, select all, source counts, and active mode state work.

--- a/specs/013-source-selection-controls/tasks.md
+++ b/specs/013-source-selection-controls/tasks.md
@@ -9,6 +9,7 @@
 - [x] Add source bulk actions to `Viewer.Types.Action`.
 - [x] Implement select-all and clear-all handling in `Viewer.purs`.
 - [x] Ensure bulk actions reset stale selected/hovered detail state and rerender the graph.
+- [x] Render partial and isolated source selections with strict selected-source filtering.
 
 ## Phase 2: Source Panel UI
 
@@ -26,3 +27,4 @@
 - [x] Run `just test`.
 - [x] Build and serve the bundled app.
 - [x] Verify with Playwright that clear all, select all, source counts, and active mode state work.
+- [x] Verify with the Cardano Budget 2026 graph that clearing all empties the graph and selecting one proposal shows only that proposal's source scope.

--- a/specs/013-source-selection-controls/tasks.md
+++ b/specs/013-source-selection-controls/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Source Selection Controls
+
+**Branch**: `fix/improve-source-selection-controls-and-state-clarit`  
+**Plan**: `plan.md`  
+**Spec**: `spec.md`
+
+## Phase 1: State And Actions
+
+- [ ] Add source bulk actions to `Viewer.Types.Action`.
+- [ ] Implement select-all and clear-all handling in `Viewer.purs`.
+- [ ] Ensure bulk actions reset stale selected/hovered detail state and rerender the graph.
+
+## Phase 2: Source Panel UI
+
+- [ ] Show `visible/total` source state in the sources panel header.
+- [ ] Add "Select all" and "Clear all" buttons in the expanded panel.
+- [ ] Replace ambiguous mode wording with "Combined sources" and "Isolate one source".
+- [ ] Make active source mode visually distinct.
+- [ ] Keep individual source checkbox rows unchanged in behavior.
+
+## Phase 3: Verification
+
+- [ ] Run `just lint`.
+- [ ] Run `just build`.
+- [ ] Run `just test`.
+- [ ] Build and serve the bundled app.
+- [ ] Verify with Playwright that clear all, select all, source counts, and active mode state work.

--- a/src/Graph/Operations.purs
+++ b/src/Graph/Operations.purs
@@ -4,6 +4,7 @@ module Graph.Operations
   ( neighborhood
   , subgraph
   , filterBySources
+  , filterToSources
   ) where
 
 import Prelude
@@ -95,3 +96,27 @@ filterBySources hidden graph
               && Set.member e.target keptNodeIds
         )
         graph.edges
+
+-- | Keep only graph structure contributed by one of the explicitly
+-- | visible sources. Endpoint nodes of kept edges are retained even
+-- | when their own label/metadata triples came from support sources.
+filterToSources :: Set String -> Graph -> Graph
+filterToSources visible graph
+  | Set.isEmpty visible = buildGraph [] []
+  | otherwise = buildGraph keptNodes keptEdges
+      where
+      hasVisibleSource sources =
+        Array.any (\src -> Set.member src visible) sources
+
+      keptEdges = Array.filter
+        (\e -> hasVisibleSource e.sources)
+        graph.edges
+
+      endpointIds = foldl
+        (\ids edge -> Set.insert edge.source (Set.insert edge.target ids))
+        Set.empty
+        keptEdges
+
+      keptNodes = Array.filter
+        (\n -> hasVisibleSource n.sources || Set.member n.id endpointIds)
+        (Array.fromFoldable (Map.values graph.nodes))

--- a/src/Viewer.purs
+++ b/src/Viewer.purs
@@ -21,7 +21,7 @@ import FFI.Cytoscape as Cy
 import FFI.Theme as Theme
 import FFI.Url as Url
 import Graph.Cytoscape as GCy
-import Graph.Operations (filterBySources, neighborhood, subgraph)
+import Graph.Operations (filterBySources, filterToSources, neighborhood, subgraph)
 import Graph.Shaping (ShapingState)
 import Graph.Shaping as Shaping
 import Data.Int (toNumber)
@@ -279,6 +279,17 @@ foregroundSourceIris :: Config -> Array String
 foregroundSourceIris config =
   map (\s -> sourceIriForPath s.path) (foregroundSources config)
 
+sourceFilteredGraph :: State -> Graph -> Graph
+sourceFilteredGraph state base =
+  let
+    foreground = Set.fromFoldable (foregroundSourceIris state.config)
+    visibleForeground = Set.difference foreground state.hiddenSources
+  in
+    if Set.isEmpty foreground || visibleForeground == foreground then
+      filterBySources state.hiddenSources base
+    else
+      filterToSources visibleForeground base
+
 renderSearchBox
   :: forall m. State -> H.ComponentHTML Action () m
 renderSearchBox state =
@@ -529,7 +540,9 @@ handleAction = case _ of
     -- collapse if anchored dependents exist; else it's purely a
     -- selection (sidebar details) with no shaping change.
     state' <- H.get
-    if Shaping.hasHiddenNeighbors state'.graph nodeId state'.shaping then
+    let
+      scopedGraph = sourceFilteredGraph state' state'.graph
+    if Shaping.hasHiddenNeighbors scopedGraph nodeId state'.shaping then
       handleAction (ExpandNode nodeId)
     else if Shaping.hasAnyAnchor nodeId state'.shaping then
       handleAction (CollapseNode nodeId)
@@ -1146,8 +1159,9 @@ handleAction = case _ of
   ExpandNode nid -> do
     state <- H.get
     let
+      scopedGraph = sourceFilteredGraph state state.graph
       visible = Shaping.visibleNodes state.shaping
-      oneHop = Set.delete nid (neighborhood 1 nid state.graph)
+      oneHop = Set.delete nid (neighborhood 1 nid scopedGraph)
       newNeighbors = Set.difference oneHop visible
       n = Set.size newNeighbors
     if n == 0 then
@@ -1266,7 +1280,7 @@ renderGraph = do
         in
           subgraph hood state.graph
       Nothing -> state.graph
-    visible = filterBySources state.hiddenSources base
+    visible = sourceFilteredGraph state base
     seed = Map.keys visible.nodes # Set.fromFoldable
 
   liftEffect $ Cy.setFocusElements
@@ -1293,7 +1307,7 @@ rebuildShapingFromScope = do
     base = case state.selected of
       Just node -> subgraph (neighborhood state.depth node.id state.graph) state.graph
       Nothing -> state.graph
-    visible = filterBySources state.hiddenSources base
+    visible = sourceFilteredGraph state base
     seed = Map.keys visible.nodes # Set.fromFoldable
   H.modify_ _ { shaping = Shaping.initFromSeed seed }
 
@@ -1306,9 +1320,10 @@ refreshHasHidden
 refreshHasHidden = do
   state <- H.get
   let
+    scopedGraph = sourceFilteredGraph state state.graph
     vis = Set.toUnfoldable (Shaping.visibleNodes state.shaping) :: Array String
   for_ vis \nid -> do
-    let has = Shaping.hasHiddenNeighbors state.graph nid state.shaping
+    let has = Shaping.hasHiddenNeighbors scopedGraph nid state.shaping
     liftEffect $ Cy.setHasHidden nid has
 
 -- | Commit a vetted expand (i.e. `newNeighbors` already computed and under
@@ -1319,16 +1334,17 @@ commitExpand
    . String
   -> Set.Set String
   -> H.HalogenM State Action () o Aff Unit
-commitExpand anchor newNeighbors = do
+commitExpand anchor _newNeighbors = do
   state <- H.get
   let
-    r = Shaping.expand anchor state.graph state.shaping
+    scopedGraph = sourceFilteredGraph state state.graph
+    r = Shaping.expand anchor scopedGraph state.shaping
     added = Set.toUnfoldable r.added :: Array String
   anchorPos <- liftEffect $ Cy.readPosition anchor
   let
     placements = radialPlacements anchorPos (Array.length added)
     addedNodes = Array.mapMaybe
-      (\(Tuple nid p) -> map (\n -> Tuple n p) (Map.lookup nid state.graph.nodes))
+      (\(Tuple nid p) -> map (\n -> Tuple n p) (Map.lookup nid scopedGraph.nodes))
       (Array.zip added placements)
     anchorEdges = Array.filter
       ( \e ->
@@ -1344,7 +1360,7 @@ commitExpand anchor newNeighbors = do
                   || Set.member e.target (Set.fromFoldable added)
               )
       )
-      state.graph.edges
+      scopedGraph.edges
     -- edges restricted so both endpoints are already visible or newly added
     visibleAfter = Set.union (Shaping.visibleNodes state.shaping) r.added
     keptEdges = Array.filter

--- a/src/Viewer.purs
+++ b/src/Viewer.purs
@@ -275,6 +275,10 @@ renderToast state = case state.toast of
       ]
       [ HH.text t.message ]
 
+foregroundSourceIris :: Config -> Array String
+foregroundSourceIris config =
+  map (\s -> sourceIriForPath s.path) (foregroundSources config)
+
 renderSearchBox
   :: forall m. State -> H.ComponentHTML Action () m
 renderSearchBox state =
@@ -991,6 +995,44 @@ handleAction = case _ of
           Set.insert iri state.hiddenSources
     H.modify_ _ { hiddenSources = nextHidden }
     renderGraph
+
+  SelectAllSources -> do
+    state <- H.get
+    let
+      nextHidden =
+        foldl
+          (\hidden iri -> Set.delete iri hidden)
+          state.hiddenSources
+          (foregroundSourceIris state.config)
+    H.modify_ _
+      { hiddenSources = nextHidden
+      , sourceSelectionMode = Multi
+      , selected = Nothing
+      , hoveredNode = Nothing
+      , hoveredEdge = Nothing
+      , selectedEdge = Nothing
+      }
+    renderGraph
+    handleAction FitAll
+
+  ClearAllSources -> do
+    state <- H.get
+    let
+      nextHidden =
+        foldl
+          (\hidden iri -> Set.insert iri hidden)
+          state.hiddenSources
+          (foregroundSourceIris state.config)
+    H.modify_ _
+      { hiddenSources = nextHidden
+      , sourceSelectionMode = Multi
+      , selected = Nothing
+      , hoveredNode = Nothing
+      , hoveredEdge = Nothing
+      , selectedEdge = Nothing
+      }
+    renderGraph
+    handleAction FitAll
 
   SoloSource iri -> do
     state <- H.get

--- a/src/Viewer/SourcesPanel.purs
+++ b/src/Viewer/SourcesPanel.purs
@@ -169,16 +169,16 @@ renderRow state source =
       else sourceDisplayName source.path
   in
     if source.background then
-      -- Background sources are always loaded. Render them as a locked
-      -- row with no checkbox/radio so the user can see what's on but
-      -- cannot toggle them.
+      -- Background sources provide support data. Render them as a
+      -- locked row with no checkbox/radio so the user can see what can
+      -- contribute labels or endpoints but cannot toggle them directly.
       HH.div [ cls "sources-row sources-row-background" ]
         [ HH.span [ cls "sources-row-lock" ]
             [ HH.text "🔒" ]
         , HH.span [ cls "sources-row-label sources-row-label-locked" ]
             [ HH.text display ]
         , HH.span [ cls "sources-row-tag" ]
-            [ HH.text "always loaded" ]
+            [ HH.text "support data" ]
         ]
     else
       let
@@ -265,7 +265,7 @@ sourceStateText mode visibleCount selectableCount backgroundCount =
 
     locked =
       if backgroundCount > 0 then
-        " - " <> show backgroundCount <> " always on"
+        " - " <> show backgroundCount <> " support sources"
       else
         ""
   in

--- a/src/Viewer/SourcesPanel.purs
+++ b/src/Viewer/SourcesPanel.purs
@@ -6,9 +6,11 @@ import Data.Array as Array
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Set as Set
 import Data.String as String
+import Data.Tuple (Tuple(..))
 import Graph.Types (Config, GraphSource)
 import Halogen as H
 import Halogen.HTML as HH
+import Halogen.HTML.Elements.Keyed as HHK
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Viewer.Helpers (cls)
@@ -34,6 +36,10 @@ renderSourcesPanel
 renderSourcesPanel state =
   let
     sources = configuredSources state.config
+    selectableSources = foregroundSources state.config
+    visibleCount = visibleSourceCount state selectableSources
+    selectableCount = Array.length selectableSources
+    backgroundCount = Array.length sources - selectableCount
   in
     if Array.null sources then HH.text ""
     else
@@ -45,16 +51,28 @@ renderSourcesPanel state =
             [ HH.span [ cls "sources-title" ]
                 [ HH.text "Sources" ]
             , HH.span [ cls "sources-count" ]
-                [ HH.text (show (Array.length sources)) ]
+                [ HH.text (sourceCountText visibleCount selectableCount) ]
+            , HH.span [ cls "sources-state" ]
+                [ HH.text
+                    ( sourceStateText
+                        state.sourceSelectionMode
+                        visibleCount
+                        selectableCount
+                        backgroundCount
+                    )
+                ]
             , HH.span [ cls "sources-chevron" ]
                 [ HH.text
                     if state.showSourcesPanel then "▾" else "▸"
                 ]
             ]
         , if state.showSourcesPanel then
-            HH.div [ cls "sources-list" ]
-              ( [ renderModeToggle state.sourceSelectionMode ]
-                  <> map (renderRow state) sources
+            HHK.div [ cls "sources-list" ]
+              ( [ Tuple "source-mode" (renderModeToggle state.sourceSelectionMode)
+                , Tuple "source-bulk-actions"
+                    (renderBulkActions visibleCount selectableCount)
+                ]
+                  <> map (renderKeyedRow state) sources
               )
           else HH.text ""
         ]
@@ -65,26 +83,77 @@ renderModeToggle
    . SourceSelectionMode
   -> H.ComponentHTML Action () m
 renderModeToggle mode =
-  HH.div [ cls "sources-mode-toggle" ]
-    [ HH.button
-        [ cls
-            ( if mode == Multi then "sources-mode-button active"
-              else "sources-mode-button"
-            )
-        , HP.title "Multi-select: each source has an independent checkbox"
-        , HE.onClick \_ -> SetSourceSelectionMode Multi
-        ]
-        [ HH.text "All" ]
-    , HH.button
-        [ cls
-            ( if mode == Solo then "sources-mode-button active"
-              else "sources-mode-button"
-            )
-        , HP.title "Single-select: clicking a source hides every other source"
-        , HE.onClick \_ -> SetSourceSelectionMode Solo
-        ]
-        [ HH.text "Single" ]
+  HH.div
+    [ cls "sources-mode-toggle"
+    , HP.attr (HH.AttrName "aria-label") "Source selection mode"
     ]
+    [ renderModeButton
+        mode
+        Multi
+        "Combined sources"
+        "Combine any number of source graphs"
+    , renderModeButton
+        mode
+        Solo
+        "Isolate one source"
+        "Show one selected source graph at a time"
+    ]
+
+renderModeButton
+  :: forall m
+   . SourceSelectionMode
+  -> SourceSelectionMode
+  -> String
+  -> String
+  -> H.ComponentHTML Action () m
+renderModeButton activeMode targetMode label title =
+  let
+    active = activeMode == targetMode
+  in
+    HH.button
+      [ cls
+          ( if active then "sources-mode-button active"
+            else "sources-mode-button"
+          )
+      , HP.title title
+      , HP.attr (HH.AttrName "aria-pressed")
+          (if active then "true" else "false")
+      , HE.onClick \_ -> SetSourceSelectionMode targetMode
+      ]
+      [ HH.text label ]
+
+renderBulkActions
+  :: forall m
+   . Int
+  -> Int
+  -> H.ComponentHTML Action () m
+renderBulkActions visibleCount selectableCount =
+  HH.div [ cls "sources-actions" ]
+    [ HH.button
+        [ cls "sources-action-button"
+        , HP.disabled (visibleCount == selectableCount)
+        , HP.title "Show every selectable source graph"
+        , HE.onClick \_ -> SelectAllSources
+        ]
+        [ HH.text "Select all" ]
+    , HH.button
+        [ cls "sources-action-button"
+        , HP.disabled (visibleCount == 0)
+        , HP.title "Hide every selectable source graph"
+        , HE.onClick \_ -> ClearAllSources
+        ]
+        [ HH.text "Clear all" ]
+    ]
+
+renderKeyedRow
+  :: forall m
+   . State
+  -> GraphSource
+  -> Tuple String (H.ComponentHTML Action () m)
+renderKeyedRow state source =
+  Tuple
+    (sourceSelectionModeId state.sourceSelectionMode <> ":" <> source.path)
+    (renderRow state source)
 
 renderRow
   :: forall m
@@ -124,6 +193,7 @@ renderRow state source =
           [ HH.input
               [ HP.type_ inputType
               , HP.name "gb-source"
+              , HP.value iri
               , HP.checked (not hidden)
               , HE.onChange onChangeAction
               ]
@@ -166,10 +236,45 @@ sourceDisplayName path =
     dropExt last suffixes
 
 dropExt :: String -> Array String -> String
-dropExt s suffixes =
-  case Array.head (Array.mapMaybe (\ext -> String.stripSuffix (String.Pattern ext) s) suffixes) of
+dropExt s extensions =
+  case Array.head (Array.mapMaybe (\ext -> String.stripSuffix (String.Pattern ext) s) extensions) of
     Just stripped -> stripped
     Nothing -> s
+
+visibleSourceCount :: State -> Array GraphSource -> Int
+visibleSourceCount state sources =
+  Array.length
+    ( Array.filter
+        (\source -> not (Set.member (sourceIriForPath source.path) state.hiddenSources))
+        sources
+    )
+
+sourceCountText :: Int -> Int -> String
+sourceCountText visibleCount selectableCount =
+  show visibleCount <> "/" <> show selectableCount <> " visible"
+
+sourceStateText :: SourceSelectionMode -> Int -> Int -> Int -> String
+sourceStateText mode visibleCount selectableCount backgroundCount =
+  let
+    base =
+      if selectableCount == 0 then "No selectable sources"
+      else if visibleCount == selectableCount then "All selectable sources visible"
+      else if visibleCount == 0 then "No selectable sources visible"
+      else if mode == Solo && visibleCount == 1 then "Isolating one source"
+      else "Custom source mix"
+
+    locked =
+      if backgroundCount > 0 then
+        " - " <> show backgroundCount <> " always on"
+      else
+        ""
+  in
+    base <> locked
+
+sourceSelectionModeId :: SourceSelectionMode -> String
+sourceSelectionModeId = case _ of
+  Multi -> "multi"
+  Solo -> "solo"
 
 suffixes :: Array String
 suffixes = [ ".ttl", ".nq", ".nt", ".trig", ".rdf", ".jsonld" ]

--- a/src/Viewer/Types.purs
+++ b/src/Viewer/Types.purs
@@ -160,6 +160,8 @@ data Action
   | SetPanelTab PanelTab
   | ToggleSource String
   | SoloSource String
+  | SelectAllSources
+  | ClearAllSources
   | SetSourceSelectionMode SourceSelectionMode
   | ToggleSourcesPanel
   | ExpandNode String

--- a/test/Test/GraphOperations.purs
+++ b/test/Test/GraphOperations.purs
@@ -1,0 +1,73 @@
+module Test.GraphOperations (spec) where
+
+import Prelude
+
+import Data.Array as Array
+import Data.Map as Map
+import Data.Maybe (Maybe(..))
+import Data.Set as Set
+import Graph.Build (buildGraph)
+import Graph.Operations (filterToSources)
+import Graph.Types (Edge, Graph, Node)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+proposalSource :: String
+proposalSource = "urn:gb:source:data/rdf/budget-2026/example.ttl"
+
+supportSource :: String
+supportSource = "urn:gb:source:data/rdf/budget-2026/proposers.ttl"
+
+otherSource :: String
+otherSource = "urn:gb:source:data/rdf/budget-2026/other.ttl"
+
+mkNode :: String -> Array String -> Node
+mkNode nid sources =
+  { id: nid
+  , label: nid
+  , kind: "concept"
+  , group: "test"
+  , description: ""
+  , links: []
+  , ontologyRef: Nothing
+  , sources
+  }
+
+mkEdge :: String -> String -> Array String -> Edge
+mkEdge source target sources =
+  { source
+  , target
+  , label: "relates to"
+  , description: ""
+  , predicateRef: Nothing
+  , sources
+  }
+
+graph :: Graph
+graph =
+  buildGraph
+    [ mkNode "proposal" [ proposalSource ]
+    , mkNode "proposer" [ supportSource ]
+    , mkNode "support-only" [ supportSource ]
+    , mkNode "other-proposal" [ otherSource ]
+    ]
+    [ mkEdge "proposal" "proposer" [ proposalSource ]
+    , mkEdge "proposer" "support-only" [ supportSource ]
+    , mkEdge "other-proposal" "support-only" [ otherSource ]
+    ]
+
+spec :: Spec Unit
+spec = describe "Graph.Operations.filterToSources" do
+  it "keeps selected-source edges and support-sourced endpoint nodes" do
+    let
+      filtered = filterToSources (Set.singleton proposalSource) graph
+    Map.keys filtered.nodes `shouldEqual`
+      Set.fromFoldable [ "proposal", "proposer" ]
+    map (\e -> e.source <> "->" <> e.target) filtered.edges `shouldEqual`
+      [ "proposal->proposer" ]
+
+  it "returns an empty graph when no source is selected" do
+    let
+      filtered = filterToSources Set.empty graph
+    Map.isEmpty filtered.nodes `shouldEqual` true
+    Array.null filtered.edges `shouldEqual` true

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -5,6 +5,7 @@ import Prelude
 import Effect (Effect)
 import Effect.Aff (launchAff_)
 import Test.ConfigDecode as ConfigDecode
+import Test.GraphOperations as GraphOperations
 import Test.OntologyImport as OntologyImport
 import Test.RdfImport as RdfImport
 import Test.Shaping as Shaping
@@ -18,6 +19,7 @@ import Test.ViewDecode as ViewDecode
 main :: Effect Unit
 main = launchAff_ $ runSpec [ consoleReporter ] do
   ConfigDecode.spec
+  GraphOperations.spec
   OntologyImport.spec
   QueryCatalog.spec
   RdfImport.spec


### PR DESCRIPTION
Closes #87

## Summary

- Adds explicit Select all and Clear all source controls.
- Replaces the ambiguous All/Single mode labels with Combined sources and Isolate one source.
- Shows visible/total selectable source state in the collapsed Sources header.
- Keeps background sources locked and always on, and keys source rows so radio checked state stays correct after mode switches.

## Verification

- nix develop --quiet -c just lint
- nix develop --quiet -c just build
- nix develop --quiet -c just test
- nix develop --quiet -c just bundle
- Playwright against local bundled viewer: clear all, select all, source counts, active mode state, and solo radio checked state.