### PR TITLE
Hide tour-only queries from the catalog

### DIFF
--- a/src/PromptBuilder.purs
+++ b/src/PromptBuilder.purs
@@ -183,6 +183,7 @@ queryCatalogSchemaBlock =
     <> "- `parameters`: optional `[{name, label, type, default}]`"
     <> " — type: `string` | `node` | `kind`\n"
     <> "- `tags`: optional — `\"view\"` for views,"
+    <> " `\"tour-only\"` to keep a query out of the Queries tab,"
     <> " `\"tour:tour-id\"` for tour stops\n"
     <> "- `layout`: optional — one of `fcose`, `elk`, `cola`,"
     <> " `dagre`, `concentric`; use it to set a default layout"

--- a/src/Viewer/QueryPanel.purs
+++ b/src/Viewer/QueryPanel.purs
@@ -108,11 +108,15 @@ renderQueriesList state =
               ]
           ]
             <> Array.concatMap mkQueryEntry
-              (filterByText state.catalogFilter state.queryCatalog)
+              ( filterByText state.catalogFilter
+                  (Array.filter (not isTourOnlyQuery) state.queryCatalog)
+              )
         )
     , renderPromptBuilder state PromptQuery "New query"
     ]
   where
+  isTourOnlyQuery q = Array.elem "tour-only" q.tags
+
   isActive q = case state.activeQuery of
     Just aq -> aq.id == q.id
     Nothing -> false


### PR DESCRIPTION
Queries tagged `tour-only` remain available for tutorial stops but are not shown in the normal Queries tab. This lets data repos promote query-backed focused tools into tours without cluttering the query catalog.\n\nValidation:\n- nix develop --quiet -c just build\n- nix develop --quiet -c just test\n- nix develop --quiet -c just bundle-lib