### PR TITLE
fix: derive useful RDF link labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ In this mode:
 - the graph itself is imported from RDF
 - `graphSources` can merge instance RDF with ontology RDF at runtime
 
+External node links are imported from `foaf:page` and `rdfs:seeAlso`.
+The viewer labels those links from the URL hostname by default, so users
+see labels like `github.com` or `hydra-voting.intersectmbo.org` instead
+of generic predicate names. For a more precise label, add an
+`rdf:Statement` for the link triple with `rdfs:label`:
+
+```turtle
+ex:proposal rdfs:seeAlso <https://milestones.projectcatalyst.io/projects/1300132> .
+
+[] a rdf:Statement ;
+  rdf:subject ex:proposal ;
+  rdf:predicate rdfs:seeAlso ;
+  rdf:object <https://milestones.projectcatalyst.io/projects/1300132> ;
+  rdfs:label "Catalyst milestone tracker" .
+```
+
 ### `data/tutorials/index.json` (optional)
 
 ```json

--- a/data/rdf/shapes.ttl
+++ b/data/rdf/shapes.ttl
@@ -88,7 +88,7 @@ gb:GroupShape a sh:NodeShape ;
     sh:maxCount 1
   ] .
 
-gb:ReifiedEdgeDescriptionShape a sh:NodeShape ;
+gb:ReifiedStatementShape a sh:NodeShape ;
   sh:targetClass rdf:Statement ;
   sh:property [
     sh:path rdf:subject ;
@@ -104,19 +104,22 @@ gb:ReifiedEdgeDescriptionShape a sh:NodeShape ;
   ] ;
   sh:property [
     sh:path rdf:object ;
-    sh:class gb:Node ;
+    sh:nodeKind sh:IRI ;
     sh:minCount 1 ;
     sh:maxCount 1
   ] ;
   sh:property [
     sh:path gb:edgeIndex ;
     sh:datatype xsd:integer ;
-    sh:minCount 1 ;
     sh:maxCount 1
   ] ;
   sh:property [
     sh:path dcterms:description ;
     sh:datatype xsd:string ;
-    sh:minCount 1 ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path rdfs:label ;
+    sh:datatype xsd:string ;
     sh:maxCount 1
   ] .

--- a/src/FFI/Uri.js
+++ b/src/FFI/Uri.js
@@ -1,4 +1,11 @@
 export const decodeUriComponent = decodeURIComponent;
 export const encodeUriComponent = encodeURIComponent;
+export const hostnameFromUrl = (url) => {
+  try {
+    return new URL(url).hostname;
+  } catch (_) {
+    return "";
+  }
+};
 export const absoluteUrl = (path) => () =>
   new URL(path, window.location.href).href;

--- a/src/FFI/Uri.purs
+++ b/src/FFI/Uri.purs
@@ -2,6 +2,7 @@ module FFI.Uri
   ( absoluteUrl
   , decodeUriComponent
   , encodeUriComponent
+  , hostnameFromUrl
   ) where
 
 import Effect (Effect)
@@ -9,6 +10,10 @@ import Effect (Effect)
 foreign import decodeUriComponent :: String -> String
 
 foreign import encodeUriComponent :: String -> String
+
+-- | Extract the hostname from an absolute URL, or return an empty string
+-- | when the URL parser rejects the input.
+foreign import hostnameFromUrl :: String -> String
 
 -- | Resolve a possibly-relative URL against the current page location,
 -- | returning an absolute URL. Needed because Oxigraph requires an

--- a/src/Rdf/Import.purs
+++ b/src/Rdf/Import.purs
@@ -16,7 +16,7 @@ import Data.String.Pattern (Pattern(..))
 import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..))
 import FFI.Oxigraph (ImportedRdfQuad)
-import FFI.Uri (decodeUriComponent)
+import FFI.Uri (decodeUriComponent, hostnameFromUrl)
 import Graph.Build (buildGraph)
 import Graph.Types (Edge, Graph, KindDef, Link, Node, OntologyReference)
 import Ontology.Extract as Ontology
@@ -85,7 +85,8 @@ importGraph quads = do
 
 importInstanceGraph :: Array ImportedRdfQuad -> Either String Graph
 importInstanceGraph quads = do
-  nodeRecords <- traverse (importNode quads) (subjectsWithType gbNode quads)
+  let reifiedLinkLabels = reifiedLabelMap quads
+  nodeRecords <- traverse (importNode quads reifiedLinkLabels) (subjectsWithType gbNode quads)
   let
     nodeIdByIri =
       Map.fromFoldable
@@ -102,8 +103,8 @@ type NodeRecord =
   , node :: Node
   }
 
-importNode :: Array ImportedRdfQuad -> String -> Either String NodeRecord
-importNode quads iri = do
+importNode :: Array ImportedRdfQuad -> Map.Map String String -> String -> Either String NodeRecord
+importNode quads reifiedLinkLabels iri = do
   id <- requireLiteral quads iri gbNodeId "node id"
   label <- requireLiteral quads iri rdfsLabel "node label"
   kind <- case findKindIri quads iri of
@@ -114,7 +115,7 @@ importNode quads iri = do
     group = fromMaybe (decodeVocabularySuffix gbGroups groupIri)
       (literalValue quads groupIri gbGroupId)
     description = fromMaybe "" (literalValue quads iri dctermsDescription)
-    links = fallbackLinks quads iri
+    links = fallbackLinks quads reifiedLinkLabels iri
     ontologyRef = semanticTypeReference quads iri
     sources = subjectSources quads iri
   pure
@@ -144,18 +145,18 @@ subjectSources quads iri =
         quads
     )
 
-fallbackLinks :: Array ImportedRdfQuad -> String -> Array Link
-fallbackLinks quads subject =
+fallbackLinks :: Array ImportedRdfQuad -> Map.Map String String -> String -> Array Link
+fallbackLinks quads reifiedLinkLabels subject =
   dedupeLinks
-    ( Array.mapMaybe (namedLink quads foafPage) (namedObjectValues quads subject foafPage)
-        <> Array.mapMaybe (namedLink quads rdfsSeeAlso) (namedObjectValues quads subject rdfsSeeAlso)
+    ( Array.mapMaybe (namedLink reifiedLinkLabels subject foafPage) (namedObjectValues quads subject foafPage)
+        <> Array.mapMaybe (namedLink reifiedLinkLabels subject rdfsSeeAlso) (namedObjectValues quads subject rdfsSeeAlso)
     )
 
-namedLink :: Array ImportedRdfQuad -> String -> String -> Maybe Link
-namedLink quads predicate url =
+namedLink :: Map.Map String String -> String -> String -> String -> Maybe Link
+namedLink reifiedLinkLabels subject predicate url =
   if isAbsoluteIri url then
     Just
-      { label: fromMaybe (decodeVocabularySuffix "" predicate) (literalValue quads predicate rdfsLabel)
+      { label: fromMaybe (hostnameLabel url) (Map.lookup (edgeKey subject predicate url) reifiedLinkLabels)
       , url
       }
   else
@@ -244,11 +245,19 @@ guardNamedNodeRelation quad nodeIdByIri =
 
 reifiedDescriptionMap :: Array ImportedRdfQuad -> Map.Map String String
 reifiedDescriptionMap quads =
+  reifiedLiteralMap quads dctermsDescription
+
+reifiedLabelMap :: Array ImportedRdfQuad -> Map.Map String String
+reifiedLabelMap quads =
+  reifiedLiteralMap quads rdfsLabel
+
+reifiedLiteralMap :: Array ImportedRdfQuad -> String -> Map.Map String String
+reifiedLiteralMap quads literalPredicate =
   foldl insertDescription Map.empty (subjectsWithType rdfStatement quads)
   where
   insertDescription acc statementIri =
     case
-      literalValue quads statementIri dctermsDescription,
+      literalValue quads statementIri literalPredicate,
       Array.head (namedObjectValues quads statementIri rdfSubject),
       Array.head (namedObjectValues quads statementIri rdfPredicate),
       Array.head (namedObjectValues quads statementIri rdfObject)
@@ -389,6 +398,22 @@ isAbsoluteIri :: String -> Boolean
 isAbsoluteIri iri =
   String.take 7 iri == "http://"
     || String.take 8 iri == "https://"
+
+hostnameLabel :: String -> String
+hostnameLabel url =
+  case stripWww (hostnameFromUrl url) of
+    "" -> decodeVocabularySuffix "" url
+    hostname -> hostname
+
+stripWww :: String -> String
+stripWww host =
+  let
+    prefix = "www."
+  in
+    if String.take (String.length prefix) host == prefix then
+      String.drop (String.length prefix) host
+    else
+      host
 
 decodeVocabularySuffix :: String -> String -> String
 decodeVocabularySuffix prefix iri

--- a/test/Test/RdfImport.purs
+++ b/test/Test/RdfImport.purs
@@ -35,13 +35,15 @@ spec = describe "RDF import standard metadata behavior" do
           Nothing -> fail "missing alice node"
           Just node -> do
             node.description `shouldEqual` "Standard Alice description"
-            map _.url node.links `shouldEqual` [ "https://example.org/alice-doc" ]
+            node.links `shouldEqual`
+              [ { label: "example.org", url: "https://example.org/alice-doc" } ]
             node.ontologyRef `shouldEqual`
               Just { label: "Student", iri: "https://example.org/standard#Student" }
         case bob of
           Nothing -> fail "missing bob node"
           Just node ->
-            map _.url node.links `shouldEqual` [ "https://example.org/bob-doc" ]
+            node.links `shouldEqual`
+              [ { label: "Bob evidence page", url: "https://example.org/bob-doc" } ]
         case knowsEdge of
           Nothing -> fail "missing knows edge"
           Just edge -> do

--- a/test/data/standard-predicate-primary.ttl
+++ b/test/data/standard-predicate-primary.ttl
@@ -20,6 +20,10 @@ ex:knows a owl:ObjectProperty ;
 ex:advises a owl:ObjectProperty ;
   rdfs:label "advises" .
 
+foaf:page rdfs:label "source page" .
+
+rdfs:seeAlso rdfs:label "supporting evidence" .
+
 ex:alice a gb:Node, gbk:component, ex:Student ;
   gb:nodeId "alice" ;
   rdfs:label "Alice" ;
@@ -33,6 +37,12 @@ ex:bob a gb:Node, gbk:component, ex:Mentor ;
   gb:group gbg:instances ;
   dcterms:description "Standard Bob description" ;
   rdfs:seeAlso <https://example.org/bob-doc> .
+
+[] a rdf:Statement ;
+  rdf:subject ex:bob ;
+  rdf:predicate rdfs:seeAlso ;
+  rdf:object <https://example.org/bob-doc> ;
+  rdfs:label "Bob evidence page" .
 
 ex:carol a gb:Node, gbk:component, ex:Student ;
   gb:nodeId "carol" ;


### PR DESCRIPTION
Closes #84

## Summary

- derive RDF node link labels from the URL hostname instead of generic `foaf:page` / `rdfs:seeAlso` predicate labels
- support explicit per-link labels via `rdf:Statement` + `rdfs:label`
- relax the RDF statement SHACL shape so labeled external link statements are valid
- document the RDF pattern and cover generic predicate labels plus explicit link labels in tests

## Verification

- `nix develop --quiet -c just ci`

Note: the CI export step rewrites `data/rdf/graph.ttl` and `data/rdf/graph.nq` ordering even on the clean base; that generated churn is intentionally not part of this PR.